### PR TITLE
Fix knob schema never loading after `server_bin` changes or `--help` failures

### DIFF
--- a/backend/argspec.py
+++ b/backend/argspec.py
@@ -136,12 +136,26 @@ def parse_help(text):
 
 def build_schema(server_bin):
     """Run the server's --help and return grouped, editable knobs."""
+    if not server_bin:
+        return {"error": "server_bin is not set in config.json", "groups": []}
     try:
-        out = subprocess.run([server_bin, "--help"], capture_output=True,
-                             text=True, timeout=20).stdout
+        # utf-8 explicitly: text=True alone decodes with the locale codepage on
+        # Windows (cp1252), which can blow up or mangle upstream help text.
+        r = subprocess.run([server_bin, "--help"], capture_output=True,
+                           text=True, encoding="utf-8", errors="replace",
+                           timeout=20)
     except Exception as e:
         return {"error": str(e), "groups": []}
+    # some builds/forks route usage through the log system -> stderr
+    out = r.stdout if r.stdout.strip() else r.stderr
+    if not out.strip():
+        return {"error": f"`{server_bin} --help` produced no output "
+                         f"(exit code {r.returncode}) - missing DLLs or wrong binary?",
+                "groups": []}
     items = [i for i in parse_help(out) if not i["reserved"]]
+    if not items:
+        return {"error": "could not parse any arguments from --help output "
+                         "(unrecognized help format?)", "groups": []}
     groups = {}
     for it in items:
         groups.setdefault(it["section"], []).append(it)

--- a/backend/server.py
+++ b/backend/server.py
@@ -37,7 +37,8 @@ def download_dir():
     if c.get("model_dirs"):
         return os.path.join(c["model_dirs"][0], "LlamaForge-downloads")
     return os.path.join(ROOT, "models")
-_SCHEMA = None   # cached knob schema
+_SCHEMA = None       # cached knob schema
+_SCHEMA_KEY = None   # (server_bin, mtime) the cache was built from
 
 def cfg():          return config.load()
 def router_base():  return f"http://127.0.0.1:{cfg()['router_port']}"
@@ -77,9 +78,21 @@ def _gpu_telemetry():
     return res
 
 def schema():
-    global _SCHEMA
-    if _SCHEMA is None:
-        _SCHEMA = argspec.build_schema(cfg()["server_bin"])
+    """Knob schema, cached per (server_bin path, binary mtime).
+
+    Keying on the mtime means the cache self-invalidates when config.json is
+    repointed at a different binary or the binary is rebuilt. Failed attempts
+    are never cached, so fixing the config takes effect without a backend
+    restart."""
+    global _SCHEMA, _SCHEMA_KEY
+    bin_ = cfg()["server_bin"]
+    try:
+        key = (bin_, os.path.getmtime(bin_))
+    except OSError:
+        key = (bin_, None)
+    if _SCHEMA is None or _SCHEMA_KEY != key or _SCHEMA.get("error"):
+        _SCHEMA = argspec.build_schema(bin_)
+        _SCHEMA_KEY = key
     return _SCHEMA
 
 # ---------- model list (router status + ini settings) ----------

--- a/web/app.js
+++ b/web/app.js
@@ -54,7 +54,9 @@ function knobField(m,k){
 }
 function editor(m){
   if(!m.in_ini) return `<div class="note">Auto-discovered (not in models.ini) &mdash; add it via Setup &rarr; Scan Drives to tune it here.</div>`;
-  if(!SCHEMA||!SCHEMA.groups) return `<div class="note">Loading knob schema...</div>`;
+  if(!SCHEMA) return `<div class="note">Loading knob schema...</div>`;
+  if(SCHEMA.error) return `<div class="note" style="color:var(--red)">Could not read knobs from <code>llama-server --help</code>: ${esc(SCHEMA.error)}<br>Check <code>server_bin</code> in config.json - the schema is retried automatically once it's fixed.</div>`;
+  if(!SCHEMA.groups||!SCHEMA.groups.length) return `<div class="note">llama-server --help returned no tunable arguments.</div>`;
   const groups=SCHEMA.groups.map((g,gi)=>{
     const flds=g.knobs.map(k=>knobField(m,k)).join("");
     return `<details class="kgroup" ${gi===0?"open":""}><summary>${esc(g.name)} &middot; ${g.knobs.length}</summary><div class="kgrid">${flds}</div></details>`;
@@ -142,6 +144,7 @@ function restoreEditorState(snap){
 async function refresh(silent){
   try{
     const snap=silent?captureEditorState():null;
+    if(!SCHEMA||SCHEMA.error||!(SCHEMA.groups||[]).length) SCHEMA=await api("/api/schema");
     const s=await api("/api/state");STATE=s;renderGpus(s.gpus);renderModels();
     restoreEditorState(snap);
   }


### PR DESCRIPTION
## Problem

The knob schema is built from `llama-server --help` exactly once per backend process and cached forever — **including failures** (`server.py`):

```python
_SCHEMA = None
def schema():
    global _SCHEMA
    if _SCHEMA is None:
        _SCHEMA = argspec.build_schema(cfg()["server_bin"])
    return _SCHEMA
```

There is no invalidation: not when `config.json` is repointed at a different binary, not after a rebuild, not on error. The frontend requests `/api/schema` once at page load, so the failure sequence is easy to hit:

1. Start the dashboard before `config.json` points at a valid `llama-server` (or edit `config.json` while the backend is running).
2. The page-load schema fetch caches `{"error": ..., "groups": []}` (or an empty schema).
3. Fix `config.json` and start the router — the router path (`router_ctl.start`) reads config fresh each time, so **the server launches fine**, but the Models tab shows zero knobs until the backend process is restarted.

The failure is silent end-to-end:

- `build_schema` ignored the subprocess return code and stderr, so a binary that dies on launch (e.g. missing DLLs next to a self-built `llama-server.exe`) produced an empty-but-"successful" schema.
- `text=True` without an explicit encoding decodes with the locale codepage on Windows (cp1252), not UTF-8.
- In `app.js`, an `{"error": ...}` payload was never rendered, and an empty `groups` array drew the filter toolbar with no sections — indistinguishable from "no options".

Verified against a real BeeLlama v0.3.2 binary (fork of llama.cpp, build 10316): the *parser* handles its `--help` fine (260 knobs, 4 sections) — the knobs were missing purely because of the stale cached failure.

## Fix

**`backend/argspec.py`**
- Decode `--help` output as UTF-8 explicitly (`encoding="utf-8", errors="replace"`).
- Fall back to stderr when stdout is empty (some builds route usage through the log system).
- Return a descriptive error when the process produces no output (including the exit code — catches missing-DLL launch failures) or when parsing yields zero arguments.

**`backend/server.py`**
- Key the schema cache on `(server_bin, binary mtime)` so it self-invalidates when `config.json` is repointed **or** the binary is rebuilt (Build tab).
- Never cache failed attempts.

**`web/app.js`**
- Render the schema error in the knob editor (with a hint to check `server_bin`) instead of an empty toolbar / permanent "Loading knob schema...".
- Refetch the schema during `refresh()` while it is missing, errored, or empty, so fixing `config.json` recovers without even a page reload.

## Testing

- `build_schema` against a real llama-server binary (BeeLlama v0.3.2, Linux CPU build): 260 knobs, 4 groups, no error — unchanged from before the patch.
- Empty `server_bin` → `"server_bin is not set in config.json"`.
- Nonexistent path → `Errno 2` surfaced.
- Binary exiting non-zero with no output → `"produced no output (exit code 3) - missing DLLs or wrong binary?"`.
- Help printed to stderr only → parsed via fallback.
- Cache lifecycle: bad config → error (not cached) → config fixed → next call returns full schema with no backend restart; subsequent calls hit the cache (same object returned).
- `python -m py_compile` on both backend files; `node --check` on `app.js`.
