### PR TITLE
fix: only attach mmproj to vision-capable models + clear stale on re-scan

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -901,10 +901,9 @@ def post_scan_apply(req):
     entries = req.body.get("entries", [])
     for e in entries:
         keys = {"model": e["model"]}
-        if e.get("mmproj"):
-            keys["mmproj"] = e["mmproj"]
-        if e.get("embeddings"):
-            keys["embeddings"] = "true"
+        # Always pass mmproj/embeddings so stale values are cleared on re-scan.
+        keys["mmproj"] = e.get("mmproj") or None
+        keys["embeddings"] = "true" if e.get("embeddings") else None
         config.set_keys(e["id"], keys)
     config.apply_ctx_defaults()
     router("/models?reload=1")

--- a/backend/scanner.py
+++ b/backend/scanner.py
@@ -4,7 +4,7 @@ model entries the router understands. Portable: no hardcoded paths.
 Rules:
 - skip mmproj* (vision projectors; attached to their model instead)
 - skip recycle bin and obvious non-model shards handling
-- attach an mmproj sibling as the model's `mmproj`
+- attach an mmproj sibling only to vision-capable models
 - treat *embed* models as embedding endpoints
 - multi-shard sets (foo-00001-of-00005.gguf) collapse to the first shard
 - disambiguate duplicate names by parent-folder prefix
@@ -13,6 +13,12 @@ import os, re
 from collections import defaultdict
 
 import osplat
+
+# Architectures known to use an mmproj sidecar (vision/multimodal).
+_VISION_ARCHES = frozenset({
+    "clip", "mllama", "qwen2_vl", "llava", "moondream", "nanollava",
+    "idefics3", "minicpm_v", "molmo", "pixtral", "granite_vision",
+})
 
 def _windows_drives():
     import string, ctypes
@@ -108,9 +114,13 @@ def build_entries(paths):
         except OSError:
             gib = 0
         e = {"id": mk_id(p), "model": p.replace("\\", "/"), "gib": gib}
+        # Only attach mmproj if the model is vision-capable.
         mm = mmproj_by_dir.get(os.path.dirname(p))
         if mm:
-            e["mmproj"] = mm.replace("\\", "/")
+            from gguf import metadata
+            arch = (metadata(p) or {}).get("architecture", "")
+            if arch in _VISION_ARCHES:
+                e["mmproj"] = mm.replace("\\", "/")
         if _is_embed(p):
             e["embeddings"] = True
         entries.append(e)


### PR DESCRIPTION
Fixes two bugs where a stray mmproj in a flat model folder would break text-only models.

- scanner.py: check GGUF architecture against known vision arches before attaching mmproj sidecar
- routes.py: always pass mmproj/embeddings keys to set_keys (None to remove) so stale values are cleared when a model is re-scanned without them

Fixes #7