### PR TITLE
Fix model loading, land ik_llama correctly, and repair form styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # machine-specific - never commit
 config.json
 models.ini
+# timestamped copies the app (and past rescues) leave beside them
+config.json.backup-*
+models.ini.backup-*
 stats.json
 wiki/
 logs/

--- a/backend/backends.py
+++ b/backend/backends.py
@@ -32,7 +32,7 @@ Pure stdlib.
 """
 import os
 
-import config, osplat, vllm_ctl, vllm_registry, wsl
+import osplat, vllm_ctl, vllm_registry, wsl
 
 
 class Unsupported(Exception):
@@ -179,12 +179,43 @@ STATE_MAP = {"ready": "loaded", "loading": "loading", "starting": "loading",
              "failed": "offline", "stopped": "offline"}
 
 
+class IkLlamaBackend(LlamaCppBackend):
+    """GGUF models served by ik_llama (ikawrakow's llama.cpp fork).
+
+    It speaks the same router API as llama.cpp, so it inherits everything except
+    which binary is on the other end and which knob schema that binary reports."""
+    name = "ikllama"
+
+    def available(self):
+        sbin = self._d.cfg().get("ik_llama_server_bin", "")
+        return bool(sbin and os.path.exists(sbin))
+
+    def schema(self):
+        return self._d.ik_schema()
+
+
+# Engines that drive llama.cpp's router. Only one can own the router at a time,
+# so `state()` reports the active one and skips its sibling rather than listing
+# the same models twice.
+LLAMA_FAMILY = ("llamacpp", "ikllama")
+
+
 class Registry:
     """The set of engines this install can use, and the lookup that lets a route
     act on a model without knowing which engine owns it."""
 
     def __init__(self, deps):
-        self._backends = [LlamaCppBackend(deps), VllmBackend(deps)]
+        self._d = deps
+        self._backends = [LlamaCppBackend(deps), IkLlamaBackend(deps), VllmBackend(deps)]
+
+    def active_engine(self):
+        """Which llama-family engine owns the router right now.
+
+        Read through the injected deps like everything else here, and validated:
+        /api/state polls this every few seconds, so a stray value in config.json
+        must degrade to the default rather than 500 the whole dashboard."""
+        name = self._d.cfg().get("active_engine", "llamacpp")
+        return name if name in LLAMA_FAMILY else "llamacpp"
 
     def all(self):
         return list(self._backends)
@@ -207,13 +238,18 @@ class Registry:
     def state(self):
         """{"models": [...], "global": {...}} across every usable engine, ordered
         loaded-first then by id - the order the model list has always used.
-        `global` stays llama.cpp's [*] section; it is a models.ini concept."""
-        llama = self.get("llamacpp")
-        base = llama.state()
+        `global` stays the active engine's [*] section; it is a models.ini concept."""
+        active = self.active_engine()
+        base_backend = self.get(active)
+        base = base_backend.state()
         rows = list(base["models"])
         for b in self.enabled():
-            if b is not llama:
-                rows.extend(b.list_models())
+            if b is base_backend:
+                continue
+            # The idle llama-family sibling would re-list the same router rows.
+            if b.name in LLAMA_FAMILY:
+                continue
+            rows.extend(b.list_models())
         rows.sort(key=lambda m: (m["status"] != "loaded", m["id"]))
         return {"models": rows, "global": base.get("global", {})}
 
@@ -227,7 +263,14 @@ class Registry:
         has - taking it avoids listing every engine's models just to route one
         click. It is only trusted if it names a usable engine; otherwise we look
         the id up, and fall back to llama.cpp so ids that predate the registry
-        resolve the way they always did."""
+        resolve the way they always did.
+
+        A llama-family hint is snapped to whichever of those engines is active:
+        an open tab can hold a row tagged with the engine that was current when
+        it rendered, and honouring that stale tag would edit knobs against the
+        wrong binary's schema."""
+        if hint in LLAMA_FAMILY:
+            return self.get(self.active_engine())
         if hint and self.supports(hint):
             return self.get(hint)
         for b in self.enabled():

--- a/backend/builder.py
+++ b/backend/builder.py
@@ -9,10 +9,10 @@ UPDATE_TTL      = 900   # seconds a successful upstream check stays cached
 UPDATE_TTL_FAIL = 60    # failed fetches retry sooner, but never per-click
 
 class BuildManager:
-    def __init__(self, log_dir):
+    def __init__(self, log_dir, log_name="build"):
         self.log_dir = log_dir
         os.makedirs(log_dir, exist_ok=True)
-        self.log_path = os.path.join(log_dir, "build.log")
+        self.log_path = os.path.join(log_dir, f"{log_name}.log")
         self.lock = threading.Lock()
         self.state = {"running": False, "phase": "idle", "returncode": None,
                       "started": None, "finished": None}

--- a/backend/config.py
+++ b/backend/config.py
@@ -35,6 +35,16 @@ DEFAULTS = {
     "vllm_port":   8081,                      # port vLLM serves on (WSL localhost-forwarded to Windows)
     "cmake_flags": {},                       # persisted build flags (from hardware detect)
     "git_remote":  "https://github.com/ggml-org/llama.cpp",
+    # ik_llama mirrors the llama.cpp path trio and, like it, ships empty: these
+    # belong to bootstrap and this machine, not to the defaults every install
+    # inherits. An unset ik_llama_server_bin simply leaves the engine disabled.
+    "ik_llama_src":    "",                    # git checkout of ik_llama.cpp
+    "ik_llama_build_dir": "",                 # cmake build dir (usually <src>/build)
+    "ik_llama_server_bin": "",                # path to ik_llama's llama-server(.exe)
+    "ik_llama_models_ini": "",                # its own models.ini ("" -> sibling of models_ini)
+    "ik_llama_git_remote": "https://github.com/ikawrakow/ik_llama.cpp",
+    "ik_llama_cmake_flags": {},               # separate build flags for ik_llama
+    "active_engine": "llamacpp",              # which binary the router uses: llamacpp | ikllama
     "auto_load_model": "",                    # model id to load automatically on launch ("" = none)
     "presets":     {},                       # named knob sets: {name: {knob: value}}
     "ui_mode":     "lite",                    # "lite" (curated knobs) or "advanced" (all ~220)
@@ -150,7 +160,20 @@ def migrate():
 _INI_LOCK = threading.RLock()
 
 def ini_path():
-    return load()["models_ini"]
+    """The models.ini the active engine reads.
+
+    ik_llama gets its own registry because the two binaries accept different
+    knobs; when the user has not named one, derive a sibling of the llama.cpp
+    file. Split on the extension rather than str.replace(".ini", ...), which is
+    a global replace and rewrites any directory that happens to contain ".ini"."""
+    c = load()
+    if c.get("active_engine") == "ikllama":
+        p = c.get("ik_llama_models_ini")
+        if p:
+            return p
+        stem, ext = os.path.splitext(c["models_ini"])
+        return stem + "-ikllama" + (ext or ".ini")
+    return c["models_ini"]
 
 def read_sections(path=None):
     """Return {section: {key: value}} for all sections including [*]."""
@@ -320,11 +343,19 @@ def apply_ctx_defaults(path=None):
     """Set sane ctx-size defaults across models.ini, idempotently.
 
     - global [*]: ctx-size = 150000 (the baseline for models that support it)
-    - each model: an explicit ctx-size only when it can't reach the global -
-      100000, capped at the model's GGUF-trained length (never over-extends).
-      Models that support >= 150000 have their per-model override removed so they
-      inherit the global; models whose trained length can't be read are left
-      untouched. Only sections that actually change are rewritten.
+    - each model with no ctx-size of its own: get one when it can't reach the
+      global - 100000, capped at the model's GGUF-trained length.
+    - each model that already has one: keep it, except to clamp a value that
+      over-extends past the trained length.
+
+    This runs on every panel startup, so it only ever fills a gap or clamps an
+    impossible value; it never overrules a ctx-size that is already there.
+    A trained length is not a VRAM budget: a 27B Q6_K trained to 262144 still
+    OOMs at 150000 on a 32 GB box, and the explicit 65536 sitting in the file is
+    how the user encoded that. Deleting it (the old behaviour, on the theory
+    that the model "supports the global") silently reimposed a config that could
+    not load. Models whose trained length can't be read are left untouched, and
+    only sections that actually change are rewritten.
 
     Returns {"changed": [section, ...]}.
     """
@@ -353,11 +384,17 @@ def apply_ctx_defaults(path=None):
             if d is None:                   # unknown trained length -> leave as-is
                 continue
             cur = kv.get("ctx-size")
-            if d == 0:                      # supports the global default
-                if cur is not None:
-                    _set_keys_locked(sec, {"ctx-size": None}, path)
-                    changed.append(sec)
-            elif cur != str(d):             # needs an explicit smaller override
+            if d == 0:                      # can reach the global; nothing to add
+                continue
+            if cur is None:                 # gap -> fill it
+                _set_keys_locked(sec, {"ctx-size": str(d)}, path)
+                changed.append(sec)
+                continue
+            try:                            # present -> only clamp over-extension
+                over = int(cur) > d
+            except ValueError:              # unparseable: the user's problem, not ours
+                continue
+            if over:
                 _set_keys_locked(sec, {"ctx-size": str(d)}, path)
                 changed.append(sec)
         return {"changed": changed}

--- a/backend/router_ctl.py
+++ b/backend/router_ctl.py
@@ -21,6 +21,40 @@ def lan_ip():
     finally:
         s.close()
 
+# ---------------------------------------------------------------- capability
+# The router is driven as `<server_bin> --models-preset <ini> --models-max 1`.
+# Not every llama-family binary can do that: ik_llama.cpp forked before router
+# mode existed and answers `unknown argument: --models-preset`, which would take
+# the router down and leave the dashboard with nothing to talk to. Ask first.
+#
+# Cached on (path, mtime) like the knob schema, and for the same reason: a
+# rebuild re-probes, and a failed probe is never cached so fixing the binary
+# takes effect without restarting the backend.
+_ROUTER_MODE = {}
+
+def clear_router_mode_cache():
+    _ROUTER_MODE.clear()
+
+def supports_router_mode(server_bin):
+    if not server_bin:
+        return False
+    try:
+        key = (server_bin, os.path.getmtime(server_bin))
+    except OSError:
+        return False
+    if key in _ROUTER_MODE:
+        return _ROUTER_MODE[key]
+    try:
+        out = subprocess.check_output([server_bin, "--help"], text=True, timeout=25,
+                                      stderr=subprocess.STDOUT,
+                                      creationflags=CREATE_NO_WINDOW if osplat.IS_WIN else 0)
+    except Exception:
+        return False                      # unreadable -> not cached
+    ok = "--models-preset" in out
+    _ROUTER_MODE[key] = ok
+    return ok
+
+
 def _pid_on_port(port):
     if not osplat.IS_WIN:
         return osplat.pid_on_port_posix(port)

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -33,7 +33,11 @@ VLLM_SUPPORTED = osplat.IS_WIN
 ROOT    = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 WEB     = os.path.join(ROOT, "web")
 LOGDIR  = os.path.join(ROOT, "logs")
-BUILDER = BuildManager(LOGDIR)
+BUILDER_LLAMA   = BuildManager(LOGDIR, "build")
+BUILDER_IKLLAMA = BuildManager(LOGDIR, "build-ikllama")
+
+def _builder_for(target):
+    return BUILDER_IKLLAMA if target == "ikllama" else BUILDER_LLAMA
 DOWNLOADS = hub.DownloadManager()
 
 VLLM_SETUP_JOB = vllm_job.WslJob(LOGDIR, "vllm-setup.log")
@@ -74,8 +78,10 @@ class Req:
 # ---------------------------------------------------------------- shared state
 _VLLM = None
 _VLLM_DL = None
-_SCHEMA = None       # cached knob schema
-_SCHEMA_KEY = None   # (server_bin, mtime) the cache was built from
+_SCHEMA = None          # cached knob schema (active engine)
+_SCHEMA_KEY = None      # (server_bin, mtime) the cache was built from
+_IK_SCHEMA = None       # cached schema for ik_llama binary
+_IK_SCHEMA_KEY = None
 _VLLM_SCHEMA = None
 
 
@@ -207,23 +213,38 @@ def _gpu_telemetry():
     return res
 
 
-def schema():
-    """Knob schema, cached per (server_bin path, binary mtime).
-
-    Keying on the mtime means the cache self-invalidates when config.json is
-    repointed at a different binary or the binary is rebuilt. Failed attempts
-    are never cached, so fixing the config takes effect without a backend
-    restart."""
-    global _SCHEMA, _SCHEMA_KEY
-    bin_ = cfg()["server_bin"]
+def _cached_schema(bin_path, cache_holder):
+    """Schema cache keyed on (binary path, mtime). Returns (schema, key)."""
+    schema, key = cache_holder
     try:
-        key = (bin_, os.path.getmtime(bin_))
+        new_key = (bin_path, os.path.getmtime(bin_path))
     except OSError:
-        key = (bin_, None)
-    if _SCHEMA is None or _SCHEMA_KEY != key or _SCHEMA.get("error"):
-        _SCHEMA = argspec.build_schema(bin_)
-        _SCHEMA_KEY = key
+        new_key = (bin_path, None)
+    if schema is None or key != new_key or schema.get("error"):
+        schema = argspec.build_schema(bin_path)
+        key = new_key
+    return schema, key
+
+
+def schema():
+    """Knob schema for the active engine, cached per (server_bin, mtime)."""
+    global _SCHEMA, _SCHEMA_KEY
+    c = cfg()
+    if c.get("active_engine") == "ikllama":
+        return ik_schema()
+    bin_ = c["server_bin"]
+    _SCHEMA, _SCHEMA_KEY = _cached_schema(bin_, (_SCHEMA, _SCHEMA_KEY))
     return _SCHEMA
+
+
+def ik_schema():
+    """Knob schema specifically for ik_llama's binary."""
+    global _IK_SCHEMA, _IK_SCHEMA_KEY
+    bin_ = cfg().get("ik_llama_server_bin", "")
+    if not bin_:
+        return {"error": "ik_llama_server_bin not configured"}
+    _IK_SCHEMA, _IK_SCHEMA_KEY = _cached_schema(bin_, (_IK_SCHEMA, _IK_SCHEMA_KEY))
+    return _IK_SCHEMA
 
 
 def vllm_schema():
@@ -599,6 +620,7 @@ def get_state(req):
     s["platform"] = osplat.current()
     s["vllm_supported"] = VLLM_SUPPORTED
     s["backends"] = [b.name for b in REGISTRY.enabled()]
+    s["active_engine"] = c.get("active_engine", "llamacpp")
     s["config_error"] = config.LOAD_ERROR
     s["onboarding"] = {
         "server_bin_ok": bool(c.get("server_bin")) and os.path.exists(c["server_bin"]),
@@ -630,17 +652,32 @@ def get_setup(req):
 
 def get_build_info(req):
     c = cfg()
+    target = req.q("target") or "llamacpp"
+    builder = _builder_for(target)
+    if target == "ikllama":
+        src = c.get("ik_llama_src", "")
+        remote = c.get("ik_llama_git_remote", "https://github.com/ikawrakow/ik_llama.cpp")
+        saved_flags = c.get("ik_llama_cmake_flags", {})
+    else:
+        src = c["llama_src"]
+        remote = c.get("git_remote", "https://github.com/ggml-org/llama.cpp")
+        saved_flags = c.get("cmake_flags", {})
     return 200, {
-        "current": BUILDER.current_commit(c["llama_src"]),
-        "updates": BUILDER.check_updates(c["llama_src"], force=req.flag("force")),
+        "target": target,
+        "current": builder.current_commit(src),
+        "updates": builder.check_updates(src, force=req.flag("force")),
         "recommended_flags": hardware.recommend()["cmake_flags"],
-        "saved_flags": c.get("cmake_flags", {}),
+        "saved_flags": saved_flags,
+        "remote": remote,
     }
 
 
 def get_build_log(req):
-    s = dict(BUILDER.state)
-    s["log"] = BUILDER.tail(300)
+    target = req.q("target") or "llamacpp"
+    builder = _builder_for(target)
+    s = dict(builder.state)
+    s["log"] = builder.tail(300)
+    s["target"] = target
     return 200, s
 
 
@@ -880,11 +917,20 @@ def post_presets_apply(req):
 
 def post_build_start(req):
     c = cfg()
-    flags = req.body.get("flags") or c.get("cmake_flags") or hardware.recommend()["cmake_flags"]
-    config.update({"cmake_flags": flags})
-    ok = BUILDER.start(c["llama_src"], c["build_dir"], flags,
-                       pull=req.body.get("pull", True))
-    return 200, {"started": ok}
+    target = req.body.get("target", "llamacpp")
+    builder = _builder_for(target)
+    if target == "ikllama":
+        src = c.get("ik_llama_src", "")
+        bdir = c.get("ik_llama_build_dir", "")
+        flags = req.body.get("flags") or c.get("ik_llama_cmake_flags") or hardware.recommend()["cmake_flags"]
+        config.update({"ik_llama_cmake_flags": flags})
+    else:
+        src = c["llama_src"]
+        bdir = c["build_dir"]
+        flags = req.body.get("flags") or c.get("cmake_flags") or hardware.recommend()["cmake_flags"]
+        config.update({"cmake_flags": flags})
+    ok = builder.start(src, bdir, flags, pull=req.body.get("pull", True))
+    return 200, {"started": ok, "target": target}
 
 
 def post_setup_install(req):
@@ -1100,6 +1146,14 @@ def post_config(req):
     return 200, out
 
 
+def _active_server_bin(c=None):
+    """Return the server binary path for the currently active engine."""
+    c = c or cfg()
+    if c.get("active_engine") == "ikllama":
+        return c.get("ik_llama_server_bin", "")
+    return c.get("server_bin", "")
+
+
 def post_network(req):
     c = cfg()
     host = req.body.get("host", "127.0.0.1")
@@ -1107,9 +1161,33 @@ def post_network(req):
     if api_key is None:
         api_key = c.get("router_api_key", "")   # field left blank -> keep existing key
     c = config.update({"router_host": host, "router_api_key": api_key})
-    ok, err = router_ctl.restart(c["server_bin"], c["models_ini"], c["router_port"],
+    sbin = _active_server_bin(c)
+    ini = config.ini_path()
+    ok, err = router_ctl.restart(sbin, ini, c["router_port"],
                                  host, api_key, LOGDIR)
     return (200 if ok else 500), {"ok": ok, "error": err, "host": host}
+
+
+def post_engine_switch(req):
+    """Switch the active engine (llamacpp / ikllama) and restart the router.
+
+    Validate the binary BEFORE persisting. `active_engine` steers ini_path(),
+    schema() and the model list, so writing it for an engine that cannot start
+    leaves the panel pointed at nothing - and the failure only shows up later,
+    somewhere else."""
+    engine = req.body.get("engine", "llamacpp")
+    if engine not in backends.LLAMA_FAMILY:
+        raise ApiError(400, f"unknown engine: {engine}")
+    c = cfg()
+    sbin = _active_server_bin(dict(c, active_engine=engine))
+    if not sbin or not os.path.exists(sbin):
+        return 200, {"ok": False, "active_engine": c.get("active_engine", "llamacpp"),
+                     "error": f"binary not found: {sbin or '(unset)'} — build {engine} first"}
+    c = config.update({"active_engine": engine})
+    ok, err = router_ctl.restart(sbin, config.ini_path(), c["router_port"],
+                                 c.get("router_host", "127.0.0.1"),
+                                 c.get("router_api_key", ""), LOGDIR)
+    return 200, {"ok": ok, "active_engine": engine, "error": err}
 
 
 def post_vllm_load(req):
@@ -1316,6 +1394,7 @@ POST_ROUTES = {
     "/api/stats/reset":         post_stats_reset,
     "/api/config":              post_config,
     "/api/network":             post_network,
+    "/api/engine/switch":       post_engine_switch,
     "/api/vllm/load":           post_vllm_load,
     "/api/vllm/unload":         post_vllm_unload,
     "/api/vllm/setup/install":  post_vllm_setup_install,

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -1179,10 +1179,18 @@ def post_engine_switch(req):
     if engine not in backends.LLAMA_FAMILY:
         raise ApiError(400, f"unknown engine: {engine}")
     c = cfg()
+    current = c.get("active_engine", "llamacpp")
     sbin = _active_server_bin(dict(c, active_engine=engine))
     if not sbin or not os.path.exists(sbin):
-        return 200, {"ok": False, "active_engine": c.get("active_engine", "llamacpp"),
+        return 200, {"ok": False, "active_engine": current,
                      "error": f"binary not found: {sbin or '(unset)'} — build {engine} first"}
+    if not router_ctl.supports_router_mode(sbin):
+        # ik_llama.cpp forked before router mode; it rejects --models-preset and
+        # serves one model per process. Switching anyway would kill the router.
+        return 200, {"ok": False, "active_engine": current,
+                     "error": f"{engine} has no router mode (its llama-server rejects "
+                              f"--models-preset), so LlamaForge cannot drive it as the "
+                              f"router. Staying on {current}."}
     c = config.update({"active_engine": engine})
     ok, err = router_ctl.restart(sbin, config.ini_path(), c["router_port"],
                                  c.get("router_host", "127.0.0.1"),

--- a/run.ps1
+++ b/run.ps1
@@ -10,19 +10,37 @@ function Listening($port){ [bool](Get-NetTCPConnection -LocalPort $port -State L
 $logDir = Join-Path $here "logs"
 New-Item -ItemType Directory -Force -Path $logDir | Out-Null
 
-# 1. llama.cpp router (only if not already up)
+# 1. llama.cpp / ik_llama router (only if not already up)
 if (-not (Listening $cfg.router_port)) {
-  if (Test-Path $cfg.server_bin) {
+  # Choose binary based on active_engine setting
+  $engine = if ($cfg.active_engine) { $cfg.active_engine } else { "llamacpp" }
+  if ($engine -eq "ikllama") {
+    $serverBin = $cfg.ik_llama_server_bin
+    $engineLabel = "ik_llama"
+    # Mirror config.ini_path(): derive a sibling of models_ini, splitting on the
+    # extension. .Replace(".ini", ...) is a global replace and would also rewrite
+    # any parent directory whose name contains ".ini".
+    $modelsIni = if ($cfg.ik_llama_models_ini) { $cfg.ik_llama_models_ini } else {
+      Join-Path ([IO.Path]::GetDirectoryName($cfg.models_ini)) `
+                ([IO.Path]::GetFileNameWithoutExtension($cfg.models_ini) + "-ikllama" +
+                 [IO.Path]::GetExtension($cfg.models_ini))
+    }
+  } else {
+    $serverBin = $cfg.server_bin
+    $engineLabel = "llama.cpp"
+    $modelsIni = $cfg.models_ini
+  }
+  if (Test-Path $serverBin) {
     $routerHost = if ($cfg.router_host) { $cfg.router_host } else { "127.0.0.1" }
-    $args = @("--models-preset", $cfg.models_ini, "--models-max", "1", "--offline",
+    $args = @("--models-preset", $modelsIni, "--models-max", "1", "--offline",
               "--host", $routerHost, "--port", "$($cfg.router_port)", "--metrics")
     if ($cfg.router_api_key) { $args += @("--api-key", $cfg.router_api_key) }
-    Start-Process -FilePath $cfg.server_bin -ArgumentList $args -WindowStyle Hidden `
+    Start-Process -FilePath $serverBin -ArgumentList $args -WindowStyle Hidden `
                   -RedirectStandardOutput (Join-Path $logDir "router.out.log") `
                   -RedirectStandardError  (Join-Path $logDir "router.err.log")
-    Write-Host "started llama.cpp router on $($routerHost):$($cfg.router_port)"
+    Write-Host "started $engineLabel router on $($routerHost):$($cfg.router_port)"
   } else {
-    Write-Host "server_bin not found ($($cfg.server_bin)) - open the dashboard Build tab to build llama.cpp first." -ForegroundColor Yellow
+    Write-Host "server_bin not found ($serverBin) - open the dashboard Build tab to build $engineLabel first." -ForegroundColor Yellow
   }
 }
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -14,17 +14,21 @@ import backends
 class FakeDeps:
     """The handful of routes.py functions a backend reaches for."""
 
-    def __init__(self, models=None, router_port=8080, globals_=None):
+    def __init__(self, models=None, router_port=8080, globals_=None, config=None):
         self._models = models or []
         self._port = router_port
         self._globals = globals_ or {}
+        self._config = config or {}
         self.router_calls = []
         self.mgr = mock.Mock()
         self.mgr.status.return_value = []
         self.dl = mock.Mock()
 
     def cfg(self):
-        return {"router_port": self._port}
+        return dict(self._config, router_port=self._port)
+
+    def ik_schema(self):
+        return {"groups": [], "count": 0}
 
     def model_state(self):
         import copy
@@ -198,9 +202,56 @@ class RegistryTest(unittest.TestCase):
         with mock.patch.object(backends.osplat, "IS_WIN", False):
             self.assertEqual(self.reg.for_model("ghost").name, "llamacpp")
 
+
+class EngineSelectionTest(unittest.TestCase):
+    """The engine question is answered from injected deps, never by reaching
+    around them into the real config.json - otherwise a developer's own machine
+    decides what the tests see."""
+
+    def _reg(self, **cfg):
+        return backends.Registry(FakeDeps(
+            models=[{"id": "qwen", "status": "offline"}], config=cfg))
+
+    def test_ikllama_is_unavailable_without_a_binary(self):
+        with mock.patch.object(backends.osplat, "IS_WIN", False):
+            names = [b.name for b in self._reg().enabled()]
+        self.assertEqual(names, ["llamacpp"])
+
+    def test_ikllama_availability_reads_injected_config_not_the_real_one(self):
+        """Point deps at a file that exists; the engine must light up from THAT,
+        with no reference to the config.json on this machine."""
+        with mock.patch.object(backends.os.path, "exists", return_value=True), \
+             mock.patch.object(backends.osplat, "IS_WIN", False):
+            reg = self._reg(ik_llama_server_bin="/nowhere/llama-server")
+            names = [b.name for b in reg.enabled()]
+        self.assertEqual(names, ["llamacpp", "ikllama"])
+
+    def test_state_uses_the_active_engine_from_deps(self):
+        with mock.patch.object(backends.os.path, "exists", return_value=True), \
+             mock.patch.object(backends.osplat, "IS_WIN", False):
+            reg = self._reg(active_engine="ikllama",
+                            ik_llama_server_bin="/nowhere/llama-server")
+            st = reg.state()
+        self.assertEqual([m["backend"] for m in st["models"]], ["ikllama"])
+
+    def test_state_lists_each_model_once_not_per_llama_engine(self):
+        """Both llama engines drive the same router, so a model must not appear
+        twice just because ik_llama happens to be built."""
+        with mock.patch.object(backends.os.path, "exists", return_value=True), \
+             mock.patch.object(backends.osplat, "IS_WIN", False):
+            st = self._reg(ik_llama_server_bin="/nowhere/llama-server").state()
+        self.assertEqual([m["id"] for m in st["models"]], ["qwen"])
+
+    def test_an_unknown_active_engine_falls_back_instead_of_raising(self):
+        """/api/state polls every few seconds; a typo in config.json must not
+        turn the whole dashboard into a 500."""
+        with mock.patch.object(backends.osplat, "IS_WIN", False):
+            st = self._reg(active_engine="typo").state()
+        self.assertEqual([m["backend"] for m in st["models"]], ["llamacpp"])
+
     def test_every_backend_satisfies_the_documented_verbs(self):
         """What a third engine has to implement."""
-        for be in self.reg.all():
+        for be in self._reg().all():
             for verb in ("available", "list_models", "schema", "load", "unload",
                          "save", "delete"):
                 self.assertTrue(callable(getattr(be, verb, None)),

--- a/tests/test_ctx_defaults.py
+++ b/tests/test_ctx_defaults.py
@@ -1,0 +1,74 @@
+"""apply_ctx_defaults() must backfill without clobbering.
+
+It runs on every panel startup (server.py main()), so anything it rewrites it
+rewrites behind the user's back. Its job is to give models a sane ctx-size when
+they have none - not to overrule one the user chose deliberately.
+
+The regression this pins: a model whose GGUF trained length exceeds the global
+default had its explicit per-model ctx-size DELETED so it would "inherit the
+global". Trained length is not a VRAM budget - a 27B Q6_K that trains to 262144
+still OOMs at 150000 on a 32 GB box - so the deletion silently reimposed a
+config that could not load.
+"""
+import conftest_paths  # noqa: F401
+import os, tempfile, unittest
+from unittest import mock
+
+import config
+
+
+class ApplyCtxDefaultsTest(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.path = os.path.join(self.dir, "models.ini")
+
+    def _write(self, text):
+        with open(self.path, "w", encoding="utf-8") as f:
+            f.write(text)
+
+    def _read(self):
+        return config.read_sections(self.path)
+
+    def _run(self, default_ctx):
+        """default_ctx: what gguf.default_ctx returns for every model here."""
+        with mock.patch.object(config.gguf, "default_ctx", return_value=default_ctx):
+            return config.apply_ctx_defaults(self.path)
+
+    def test_sets_the_global_baseline(self):
+        self._write("[a]\nmodel = /m/a.gguf\n")
+        self._run(0)
+        self.assertEqual(self._read()["*"]["ctx-size"], config.CTX_GLOBAL_DEFAULT)
+
+    def test_keeps_an_explicit_ctx_size_on_a_model_that_could_reach_the_global(self):
+        """The regression. 65536 is there because 150000 does not fit in VRAM."""
+        self._write("[*]\nctx-size = 150000\n\n[a]\nctx-size = 65536\nmodel = /m/a.gguf\n")
+        self._run(0)
+        self.assertEqual(self._read()["a"].get("ctx-size"), "65536")
+
+    def test_still_backfills_a_model_that_cannot_reach_the_global(self):
+        self._write("[*]\nctx-size = 150000\n\n[a]\nmodel = /m/a.gguf\n")
+        self._run(40000)
+        self.assertEqual(self._read()["a"].get("ctx-size"), "40000")
+
+    def test_clamps_a_value_that_over_extends_the_trained_length(self):
+        """Safety kept: never ask for more context than the model was trained on."""
+        self._write("[*]\nctx-size = 150000\n\n[a]\nctx-size = 99999\nmodel = /m/a.gguf\n")
+        self._run(40000)
+        self.assertEqual(self._read()["a"].get("ctx-size"), "40000")
+
+    def test_leaves_a_smaller_deliberate_value_below_the_cap(self):
+        self._write("[*]\nctx-size = 150000\n\n[a]\nctx-size = 8192\nmodel = /m/a.gguf\n")
+        self._run(40000)
+        self.assertEqual(self._read()["a"].get("ctx-size"), "8192")
+
+    def test_leaves_models_with_an_unreadable_trained_length_alone(self):
+        self._write("[*]\nctx-size = 150000\n\n[a]\nctx-size = 4096\nmodel = /m/a.gguf\n")
+        self._run(None)
+        self.assertEqual(self._read()["a"].get("ctx-size"), "4096")
+
+    def test_is_idempotent(self):
+        self._write("[*]\nctx-size = 150000\n\n[a]\nctx-size = 65536\nmodel = /m/a.gguf\n")
+        self._run(0)
+        second = self._run(0)
+        self.assertEqual(second["changed"], [],
+                         "a second pass rewrote sections it had already settled")

--- a/tests/test_engine_switch.py
+++ b/tests/test_engine_switch.py
@@ -1,0 +1,98 @@
+"""Switching the active engine, and deriving the per-engine models.ini path.
+
+Both are new with the ik_llama work. The switch route is the risky one: it
+writes `active_engine` into config.json and then restarts the router, so a
+write that happens before the binary is validated leaves the whole panel
+pointed at an engine that cannot start.
+"""
+import conftest_paths  # noqa: F401
+import os
+import unittest
+from unittest import mock
+
+import config, routes
+from routes import Req
+
+
+class EngineSwitchRouteTest(unittest.TestCase):
+    def setUp(self):
+        self.saved = {}
+        self.base = {"router_port": 8080, "router_host": "127.0.0.1",
+                     "router_api_key": "", "models_ini": "/tmp/models.ini",
+                     "server_bin": "/bin/llama-server", "active_engine": "llamacpp"}
+
+        def fake_update(changes):
+            self.saved.update(changes)
+            return dict(self.base, **self.saved)
+
+        for target, name, new in (
+                (config, "update", fake_update),
+                (config, "load", lambda: dict(self.base, **self.saved)),
+                (config, "ini_path", lambda: "/tmp/models.ini")):
+            p = mock.patch.object(target, name, side_effect=new) \
+                if callable(new) else None
+            p.start(); self.addCleanup(p.stop)
+
+        self.restart = mock.patch.object(
+            routes.router_ctl, "restart", return_value=(True, "")).start()
+        self.addCleanup(mock.patch.stopall)
+
+    def test_rejects_an_unknown_engine(self):
+        with self.assertRaises(routes.ApiError) as cm:
+            routes.post_engine_switch(Req(body={"engine": "vllm"}))
+        self.assertEqual(cm.exception.status, 400)
+        self.assertEqual(self.saved, {}, "config was written for a bad engine")
+
+    def test_does_not_persist_the_switch_when_the_binary_is_missing(self):
+        """The regression: config.update ran before the existence check, so a
+        failed switch still left active_engine=ikllama behind."""
+        self.base["ik_llama_server_bin"] = "/nope/llama-server"
+        with mock.patch.object(os.path, "exists", return_value=False):
+            status, out = routes.post_engine_switch(Req(body={"engine": "ikllama"}))
+        self.assertEqual(status, 200)
+        self.assertFalse(out["ok"])
+        self.assertNotIn("active_engine", self.saved)
+        self.restart.assert_not_called()
+
+    def test_persists_and_restarts_when_the_binary_is_present(self):
+        self.base["ik_llama_server_bin"] = "/opt/ik/llama-server"
+        with mock.patch.object(os.path, "exists", return_value=True):
+            status, out = routes.post_engine_switch(Req(body={"engine": "ikllama"}))
+        self.assertEqual(status, 200)
+        self.assertTrue(out["ok"])
+        self.assertEqual(self.saved["active_engine"], "ikllama")
+        self.restart.assert_called_once()
+        self.assertEqual(self.restart.call_args[0][0], "/opt/ik/llama-server")
+
+
+class IniPathTest(unittest.TestCase):
+    """`ini_path()` derives a sibling models.ini for ik_llama when none is set."""
+
+    def _path(self, cfg):
+        with mock.patch.object(config, "load", return_value=cfg):
+            return config.ini_path()
+
+    def test_llamacpp_uses_the_configured_ini(self):
+        self.assertEqual(
+            self._path({"models_ini": "D:/x/models.ini", "active_engine": "llamacpp"}),
+            "D:/x/models.ini")
+
+    def test_ikllama_prefers_its_own_explicit_ini(self):
+        self.assertEqual(
+            self._path({"models_ini": "D:/x/models.ini",
+                        "ik_llama_models_ini": "D:/x/ik.ini",
+                        "active_engine": "ikllama"}),
+            "D:/x/ik.ini")
+
+    def test_ikllama_derives_a_sibling_when_unset(self):
+        self.assertEqual(
+            self._path({"models_ini": "D:/x/models.ini", "ik_llama_models_ini": "",
+                        "active_engine": "ikllama"}),
+            os.path.join("D:/x", "models-ikllama.ini").replace("\\", "/"))
+
+    def test_derivation_does_not_maul_a_directory_named_ini(self):
+        """str.replace('.ini', ...) is global, so a directory containing '.ini'
+        got rewritten too. Only the file's extension may change."""
+        got = self._path({"models_ini": "D:/conf.ini.d/models.ini",
+                          "ik_llama_models_ini": "", "active_engine": "ikllama"})
+        self.assertEqual(got.replace("\\", "/"), "D:/conf.ini.d/models-ikllama.ini")

--- a/tests/test_engine_switch.py
+++ b/tests/test_engine_switch.py
@@ -55,8 +55,11 @@ class EngineSwitchRouteTest(unittest.TestCase):
         self.restart.assert_not_called()
 
     def test_persists_and_restarts_when_the_binary_is_present(self):
+        """Present AND router-capable: see test_router_capability.py for the
+        binary that exists but cannot be the router."""
         self.base["ik_llama_server_bin"] = "/opt/ik/llama-server"
-        with mock.patch.object(os.path, "exists", return_value=True):
+        with mock.patch.object(os.path, "exists", return_value=True), \
+             mock.patch.object(routes.router_ctl, "supports_router_mode", return_value=True):
             status, out = routes.post_engine_switch(Req(body={"engine": "ikllama"}))
         self.assertEqual(status, 200)
         self.assertTrue(out["ok"])

--- a/tests/test_router_capability.py
+++ b/tests/test_router_capability.py
@@ -1,0 +1,97 @@
+"""Whether a server binary can actually be the router.
+
+LlamaForge drives the router as `<server_bin> --models-preset <ini> --models-max 1`.
+ik_llama.cpp is a fork of pre-router llama.cpp and rejects that outright:
+
+    error: unknown argument: --models-preset
+
+Switching to it therefore persisted active_engine and then left the machine
+with no router at all. The switch has to ask the binary first.
+"""
+import conftest_paths  # noqa: F401
+import unittest
+from unittest import mock
+
+import router_ctl, routes
+from routes import Req
+
+ROUTER_HELP = "usage: llama-server\n  --models-preset PATH  ini\n  --models-max N  max\n"
+PLAIN_HELP  = "usage: llama-server\n  -m, --model FNAME  path\n  --port N  port\n"
+
+
+class SupportsRouterModeTest(unittest.TestCase):
+    def setUp(self):
+        router_ctl.clear_router_mode_cache()
+        self.addCleanup(router_ctl.clear_router_mode_cache)
+
+    def _probe(self, help_text, mtime=1.0):
+        with mock.patch.object(router_ctl.subprocess, "check_output", return_value=help_text), \
+             mock.patch.object(router_ctl.os.path, "getmtime", return_value=mtime):
+            return router_ctl.supports_router_mode("/bin/llama-server")
+
+    def test_true_when_the_binary_advertises_models_preset(self):
+        self.assertTrue(self._probe(ROUTER_HELP))
+
+    def test_false_for_a_binary_without_router_mode(self):
+        self.assertFalse(self._probe(PLAIN_HELP))
+
+    def test_false_when_the_binary_cannot_be_run(self):
+        with mock.patch.object(router_ctl.subprocess, "check_output",
+                               side_effect=OSError("nope")), \
+             mock.patch.object(router_ctl.os.path, "getmtime", return_value=1.0):
+            self.assertFalse(router_ctl.supports_router_mode("/bin/missing"))
+
+    def test_a_failed_probe_is_not_cached(self):
+        """Same rule the knob schema follows: never cache a failure, so fixing
+        the binary takes effect without restarting the backend."""
+        with mock.patch.object(router_ctl.os.path, "getmtime", return_value=1.0):
+            with mock.patch.object(router_ctl.subprocess, "check_output",
+                                   side_effect=OSError("nope")):
+                self.assertFalse(router_ctl.supports_router_mode("/bin/x"))
+            with mock.patch.object(router_ctl.subprocess, "check_output",
+                                   return_value=ROUTER_HELP) as ok:
+                self.assertTrue(router_ctl.supports_router_mode("/bin/x"))
+                ok.assert_called_once()
+
+    def test_a_success_is_cached_per_binary_mtime(self):
+        with mock.patch.object(router_ctl.os.path, "getmtime", return_value=1.0):
+            with mock.patch.object(router_ctl.subprocess, "check_output",
+                                   return_value=ROUTER_HELP) as first:
+                self.assertTrue(router_ctl.supports_router_mode("/bin/x"))
+                self.assertTrue(router_ctl.supports_router_mode("/bin/x"))
+                first.assert_called_once()
+
+
+class EngineSwitchRefusesNonRouterBinaryTest(unittest.TestCase):
+    def setUp(self):
+        self.saved = {}
+        self.base = {"router_port": 8080, "router_host": "127.0.0.1",
+                     "router_api_key": "", "models_ini": "/tmp/models.ini",
+                     "server_bin": "/bin/llama-server", "active_engine": "llamacpp",
+                     "ik_llama_server_bin": "/bin/ik/llama-server"}
+        mock.patch.object(routes.config, "load",
+                          side_effect=lambda: dict(self.base, **self.saved)).start()
+        mock.patch.object(routes.config, "update",
+                          side_effect=lambda ch: (self.saved.update(ch),
+                                                  dict(self.base, **self.saved))[1]).start()
+        mock.patch.object(routes.config, "ini_path", return_value="/tmp/models.ini").start()
+        self.restart = mock.patch.object(routes.router_ctl, "restart",
+                                         return_value=(True, "")).start()
+        mock.patch.object(routes.os.path, "exists", return_value=True).start()
+        self.addCleanup(mock.patch.stopall)
+
+    def test_refuses_and_keeps_the_current_engine(self):
+        with mock.patch.object(routes.router_ctl, "supports_router_mode", return_value=False):
+            status, out = routes.post_engine_switch(Req(body={"engine": "ikllama"}))
+        self.assertEqual(status, 200)
+        self.assertFalse(out["ok"])
+        self.assertIn("router mode", out["error"])
+        self.assertNotIn("active_engine", self.saved)
+        self.restart.assert_not_called()
+
+    def test_allows_a_binary_that_does_support_router_mode(self):
+        with mock.patch.object(routes.router_ctl, "supports_router_mode", return_value=True):
+            status, out = routes.post_engine_switch(Req(body={"engine": "ikllama"}))
+        self.assertTrue(out["ok"])
+        self.assertEqual(self.saved["active_engine"], "ikllama")
+        self.restart.assert_called_once()

--- a/web/index.html
+++ b/web/index.html
@@ -108,7 +108,11 @@ body.app{display:grid;grid-template-columns:var(--nav-w) 1fr;min-height:100vh;ma
 .side-spacer{flex:1}
 .side-settings{display:flex;flex-direction:column;gap:8px;padding-top:10px;border-top:1px solid var(--hair)}
 .side-settings .mode-toggle{margin-left:0}
-#content{min-width:0;padding:0 26px 26px}
+/* Column layout so the credit line can be pushed to the bottom instead of
+   floating under the last card on short tabs (Will-it-run was the worst case). */
+#content{min-width:0;padding:0 26px 26px;display:flex;flex-direction:column;min-height:100vh}
+#content .views{flex:1 0 auto}
+#content .credit{margin-top:auto;padding-top:22px}
 .topbar{display:flex;align-items:center;justify-content:space-between;gap:12px;
   padding:14px 0;border-bottom:1px solid var(--hair);margin-bottom:16px;position:sticky;top:0;background:var(--bg);z-index:5}
 #page-title{font-family:var(--disp);font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--ink-strong);font-size:15px}
@@ -121,7 +125,10 @@ body.app{display:grid;grid-template-columns:var(--nav-w) 1fr;min-height:100vh;ma
 .gpu .idx{color:var(--amber-text);font-size:11px;letter-spacing:.2em}
 .meter{height:22px;background:var(--inset);border:1px solid var(--hair);display:flex;gap:2px;padding:3px}
 .seg{flex:1;background:var(--seg-bg)}.seg.on{background:var(--amber);box-shadow:0 0 6px var(--amber-dim)}.seg.hot{background:var(--red)}
-.gpu .stats{display:flex;justify-content:space-between;margin-top:9px;color:var(--dim);font-size:11px}
+/* Four non-wrapping cells whose combined min-content width exceeded a phone
+   viewport, which forced horizontal overflow on the whole page - that is what
+   was clipping the row buttons, not the rows themselves. */
+.gpu .stats{display:flex;flex-wrap:wrap;gap:4px 14px;justify-content:space-between;margin-top:9px;color:var(--dim);font-size:11px}
 .gpu .stats b{color:var(--cyan-text);font-weight:500}
 .tbl-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:10px}
 .tbl-head h2{font-family:var(--disp);font-weight:600;letter-spacing:.18em;font-size:12px;color:var(--dim);text-transform:uppercase;margin:0}
@@ -162,6 +169,30 @@ body.app{display:grid;grid-template-columns:var(--nav-w) 1fr;min-height:100vh;ma
 .kgroup{border:1px solid var(--hair);margin-bottom:10px}
 .kgroup>summary{cursor:pointer;padding:9px 12px;font-family:var(--disp);letter-spacing:.12em;text-transform:uppercase;font-size:11px;color:var(--amber-text);background:var(--panel2);user-select:none}
 .kgrid{display:grid;grid-template-columns:repeat(auto-fill,minmax(190px,1fr));gap:12px;padding:14px 12px}
+/* Baseline for every native control.
+   The only input rule used to be `.fld input, .fld select`, so any control not
+   wrapped in a .fld fell through to the browser default - a white box with
+   black text on a black terminal UI. Will-it-run and Context were doing exactly
+   that. Style the elements themselves; .fld then only adds layout on top.
+   Checkboxes and radios are excluded: they want the native box, just tinted. */
+input:not([type=checkbox]):not([type=radio]),select,textarea{
+  background:var(--inset);border:1px solid var(--hair);color:var(--ink);
+  font-family:var(--mono);font-size:12px;padding:7px 9px;outline:none;border-radius:0}
+input:not([type=checkbox]):not([type=radio]):focus,select:focus,textarea:focus{border-color:var(--amber)}
+input::placeholder,textarea::placeholder{color:var(--faint);opacity:1}
+input[type=checkbox],input[type=radio]{accent-color:var(--amber);cursor:pointer}
+select{min-width:120px;cursor:pointer}
+select[multiple]{padding:4px;min-height:96px;cursor:default}
+/* Labelled control rows, for views that lay out bare inputs rather than the
+   .fld/.kgrid knob editor. */
+.formrow{display:flex;gap:10px;align-items:flex-end;flex-wrap:wrap;margin-bottom:12px}
+.formrow .f{display:flex;flex-direction:column;gap:5px;min-width:0}
+.formrow .f>.lbl{font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--dim)}
+.formrow .grow{flex:1 1 240px}
+.formrow .grow input,.formrow .grow select{width:100%}
+textarea{width:100%;min-height:140px;line-height:1.55;resize:vertical;box-sizing:border-box}
+input:disabled,select:disabled,textarea:disabled{opacity:.45;cursor:not-allowed}
+
 .fld label{display:block;font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--dim);margin-bottom:5px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .fld.set label{color:var(--cyan-text)}
 .fld input,.fld select{width:100%;background:var(--inset);border:1px solid var(--hair);color:var(--ink);font-family:var(--mono);font-size:12px;padding:7px 9px;outline:none}
@@ -268,7 +299,12 @@ body.mode-lite .advanced-only{display:none !important}
 .admon{border-left:3px solid var(--amber);background:var(--panel);padding:8px 12px;margin:10px 0}
 .admon-warning{border-left-color:var(--red)}
 .admon-tip{border-left-color:var(--green)}
-.sicon{background:transparent;border:1px solid var(--hair);border-radius:6px;color:var(--dim);cursor:pointer;
+/* These read as three empty boxes at the bottom of the rail. The glyphs were
+   in the DOM the whole time: .sicon inherits button{padding:9px 16px}, and with
+   the global border-box a 34px-wide button leaves 2px of content box, which
+   crushes the 18px icon to nothing. padding:0 is the fix. */
+.sicon{background:transparent;border:1px solid var(--hair);border-radius:6px;color:var(--ink);cursor:pointer;
+  padding:0;flex:0 0 auto;
   width:34px;height:34px;display:inline-flex;align-items:center;justify-content:center}
 .sicon:hover{color:var(--amber);border-color:var(--amber)}
 .sicon.on{color:var(--amber);border-color:var(--amber)}
@@ -277,6 +313,24 @@ body.mode-lite .advanced-only{display:none !important}
 #nav-menu{display:none;margin-right:10px}
 .scrim{position:fixed;inset:0;background:var(--overlay);z-index:40}
 .scrim[hidden]{display:none}
+/* Model rows: the fixed `14px 18px 1fr auto auto auto` grid cannot shrink, so
+   below ~760px the CTX pill, status and Load button were pushed off-screen and
+   the id ellipsed to "gemma-4-..." - three different models rendering
+   identically. Reflow to wrapped flex and give the id its own full-width line,
+   where it can wrap instead of being truncated. */
+@media (max-width:760px){
+  .rhead{display:flex;flex-wrap:wrap;gap:10px 12px}
+  .rhead .mid{flex:1 1 100%;white-space:normal;overflow:visible;overflow-wrap:anywhere;order:-1}
+  .rhead .led,.rhead .fav{flex:0 0 auto}
+  .rhead .stat{min-width:0;text-align:left;margin-left:auto}
+  .rhead .ctxpill{flex:0 0 auto}
+  .gpus{grid-template-columns:1fr}          /* GPU cards stack; side-by-side clipped TEMP */
+  .topbar{flex-wrap:wrap;gap:6px 12px}
+  .topbar .sub{font-size:10px}
+  .toolbar .search{flex:1 1 100%}
+  #content{padding:0 14px 18px}
+}
+
 @media (max-width:900px){
   :root{--nav-w:52px}                       /* force rail width */
   :root #sidebar .brand-word,

--- a/web/index.html
+++ b/web/index.html
@@ -140,6 +140,13 @@ body.app{display:grid;grid-template-columns:var(--nav-w) 1fr;min-height:100vh;ma
 .tag.vis{color:var(--cyan-text);border-color:var(--cyan-border)}
 .tag.be-vllm{color:var(--green);border-color:var(--green-border)}
 .tag.be-llamacpp{color:var(--amber-text);border-color:var(--amber-dim)}
+.tag.be-ikllama{color:var(--cyan-text);border-color:var(--cyan-border)}
+.buildtarget{display:flex;align-items:center;gap:12px;padding:10px 16px}
+.buildtarget .mode-toggle{margin-left:0}
+.buildtarget-active{margin-left:auto;font-size:12px}
+.buildtarget-active strong.ok{color:var(--green)}
+.buildtarget-active strong.dim{color:var(--dim)}
+.buildtarget-active button{margin-left:6px;font-size:11px}
 .tag.ep{color:var(--cyan-text);border-color:var(--cyan-border);cursor:pointer}
 .tag.ep:hover{color:var(--ink-strong);border-color:var(--cyan)}
 .ctxpill{font-size:11px;color:var(--amber-text);white-space:nowrap}.ctxpill .k{color:var(--dim)}
@@ -336,6 +343,7 @@ body.mode-lite .advanced-only{display:none !important}
   <div class="topbar">
     <button id="nav-menu" class="nav-toggle" title="Menu" aria-label="Open menu">&#9776;</button>
     <span id="page-title">Models</span>
+    <span id="engine-badge"></span>
     <span class="sub" id="clock"></span>
   </div>
   <div class="views">

--- a/web/js/build.js
+++ b/web/js/build.js
@@ -1,9 +1,26 @@
-// Build tab: current llama.cpp commit vs upstream, CMake flags, rebuild, log.
+// Build tab: current commit vs upstream, CMake flags, rebuild, log.
+// Supports both llama.cpp and ik_llama build targets via a toggle.
 // Also surfaces the vLLM pip package version, since updating it is a build-ish
 // concern rather than a setup one.
 import { $, esc, setHTML, api, toast, agoText, fmtDur } from "./core.js";
 
 let buildPoll = null;
+let _target = localStorage.getItem("build_target") || "llamacpp";
+
+function setTarget(t) {
+  _target = t;
+  localStorage.setItem("build_target", t);
+}
+
+const ENGINE_LABELS = {
+  llamacpp: "llama.cpp",
+  ikllama: "ik_llama",
+};
+
+const ENGINE_REPOS = {
+  llamacpp: "github.com/ggml-org/llama.cpp",
+  ikllama: "github.com/ikawrakow/ik_llama.cpp",
+};
 
 export async function loadBuild(force) {
   const v = $("#view-build");
@@ -11,20 +28,37 @@ export async function loadBuild(force) {
     const s = $("#upstream-status");
     if (s) { s.textContent = "checking github..."; s.className = "v work"; }
   } else setHTML(v, `<div class="skel">QUERYING GIT + GITHUB...</div>`);
-  const q = force ? "?force=1" : "";
+  const q = (force ? "?force=1&" : "?") + `target=${_target}`;
   const b = await api("/api/build/info" + q);
-  const vver = await api("/api/vllm/version" + q);
+  const st = await api("/api/state");
+  const activeEngine = st.active_engine || "llamacpp";
+  const vver = await api("/api/vllm/version" + (force ? "?force=1" : ""));
   const cur = b.current||{}, up = b.updates||{};
   const flags = b.saved_flags && Object.keys(b.saved_flags).length ? b.saved_flags : b.recommended_flags||{};
   const behind = up.ok ? up.behind : 0;
   const checked = up.cached ? `checked ${agoText(up.checked_secs_ago)}` : "checked just now";
+  const remoteUrl = b.remote || ENGINE_REPOS[_target] || "";
+  const label = ENGINE_LABELS[_target] || _target;
+  const isActive = _target === activeEngine;
+
   setHTML(v, `
-    <div class="card"><h3>Current Build</h3>
+    <div class="card buildtarget">
+      <span class="k">Build Target</span>
+      <span class="mode-toggle">
+        <button class="${_target==='llamacpp'?'active':''}" id="btn-tgt-llamacpp">llama.cpp</button>
+        <button class="${_target==='ikllama'?'active':''}" id="btn-tgt-ikllama">ik_llama</button>
+      </span>
+      <span class="buildtarget-active">
+        Active engine: <strong class="${isActive?'ok':'dim'}">${esc(ENGINE_LABELS[activeEngine]||activeEngine)}</strong>
+        ${!isActive?`<button class="ghost" id="btn-switch-engine">Switch to ${esc(label)}</button>`:''}
+      </span>
+    </div>
+    <div class="card"><h3>Current Build · ${esc(label)}</h3>
       <div class="kv"><span class="k">commit</span><span class="v">${esc(cur.hash||"?")} &middot; ${esc((cur.subject||"").slice(0,60))}</span></div>
       <div class="kv"><span class="k">branch</span><span class="v">${esc(cur.branch||"?")}</span></div>
       <div class="kv"><span class="k">date</span><span class="v">${esc(cur.date||"?")}</span></div>
     </div>
-    <div class="card"><h3>Upstream (github.com/ggml-org/llama.cpp)</h3>
+    <div class="card"><h3>Upstream (${esc(remoteUrl)})</h3>
       <div class="kv"><span class="k">status</span><span class="v ${behind>0?'bad':'ok'}" id="upstream-status">${up.ok?(behind>0?behind+" commits behind":"up to date"):"check failed"}</span></div>
       ${up.latest?`<div class="kv"><span class="k">latest</span><span class="v">${esc(up.latest.hash)} &middot; ${esc((up.latest.subject||"").slice(0,60))}</span></div>`:""}
       <div class="actions" style="margin-top:6px">
@@ -32,22 +66,43 @@ export async function loadBuild(force) {
         <span class="note" style="margin:0">${esc(checked)} &middot; auto-checks at most every 15 min</span>
       </div>
     </div>
-    <div class="card"><h3>Build Flags (auto-detected for this machine)</h3>
+    <div class="card"><h3>Build Flags · ${esc(label)}</h3>
       <div class="flags">${Object.entries(flags).map(([k,val])=>`<span class="flagpill">${esc(k)}=${esc(val)}</span>`).join("")}</div>
       <div class="actions">
         <button class="primary" id="btn-build">${behind>0?"Pull latest &amp; Rebuild":"Rebuild current"}</button>
         <label style="font-size:11px;color:var(--dim)"><input type="checkbox" id="opt-pull" ${behind>0?"checked":""}> git pull first</label>
         <span class="msg" id="build-msg"></span>
       </div>
-      <div class="note">Rebuilds llama.cpp with CMake. Prior binaries are backed up first. Takes several minutes; watch the log below.</div>
+      <div class="note">Rebuilds ${esc(label)} with CMake. Prior binaries are backed up first. Takes several minutes; watch the log below.</div>
     </div>
-    <div class="card"><h3>Build Log</h3><div class="log" id="build-log">idle</div></div>`
+    <div class="card"><h3>Build Log · ${esc(label)}</h3><div class="log" id="build-log">idle</div></div>`
     + (vver.error ? "" : `<div class="card"><h3>vLLM (pip package in WSL)</h3>
       <div class="kv"><span class="k">installed</span><span class="v ${vver.installed&&vver.installed.present?'ok':'bad'}">${vver.installed&&vver.installed.present?"v"+esc(vver.installed.version):"not installed (see Setup)"}</span></div>
       <div class="kv"><span class="k">latest on PyPI</span><span class="v">${esc(vver.latest||"?")}</span></div>
       ${vver.installed&&vver.installed.present&&vver.latest&&vver.latest!==vver.installed.version?`<div class="actions"><button class="primary" id="btn-vllm-update">Update vLLM to ${esc(vver.latest)}</button><span class="msg" id="vllm-upd-msg"></span></div>`:`<div class="note">${vver.installed&&vver.installed.present?"vLLM is up to date.":"Install vLLM from the Setup tab first."}</div>`}
       <div class="log" id="vllm-update-log" style="display:none">idle</div>
     </div>`));
+
+  // Target toggle
+  $("#btn-tgt-llamacpp").onclick = () => { setTarget("llamacpp"); loadBuild(); };
+  $("#btn-tgt-ikllama").onclick = () => { setTarget("ikllama"); loadBuild(); };
+
+  // Engine switch
+  const switchBtn = $("#btn-switch-engine");
+  if (switchBtn) switchBtn.onclick = async () => {
+    switchBtn.disabled = true;
+    switchBtn.textContent = "switching...";
+    const r = await api("/api/engine/switch", {engine: _target});
+    if (r.ok) {
+      toast(`Switched to ${label}`, "ok");
+      setTimeout(loadBuild, 1500);
+    } else {
+      toast(r.error || "switch failed", "err");
+      switchBtn.disabled = false;
+      switchBtn.textContent = `Switch to ${label}`;
+    }
+  };
+
   $("#btn-build").onclick = startBuild;
   const refBtn = $("#btn-refresh-upstream");
   if (refBtn) refBtn.onclick = () => { refBtn.disabled = true; loadBuild(true); };
@@ -75,8 +130,8 @@ export async function loadBuild(force) {
 async function startBuild() {
   const pull = $("#opt-pull").checked, msg = $("#build-msg");
   msg.className = "msg work"; msg.textContent = "starting build...";
-  const r = await api("/api/build/start", {pull});
-  if (r.started) toast("Build started", "ok");
+  const r = await api("/api/build/start", {pull, target: _target});
+  if (r.started) toast(`Build started (${ENGINE_LABELS[_target]})`, "ok");
   else msg.textContent = "a build is already running";
   pollBuild();
 }
@@ -84,7 +139,7 @@ async function startBuild() {
 async function pollBuild() {
   clearInterval(buildPoll);
   const tick = async () => {
-    const s = await api("/api/build/log");
+    const s = await api("/api/build/log?target=" + _target);
     const log = $("#build-log");
     if (log) { log.textContent = s.log||"idle"; log.scrollTop = log.scrollHeight; }
     const msg = $("#build-msg");

--- a/web/js/context.js
+++ b/web/js/context.js
@@ -10,27 +10,47 @@ export async function loadContext() {
   const ids = models().map(m => m.id);
   setHTML(v, `
     <div class="card"><h3>Context docs</h3>
-      <select id="wk-doc">${docs.map(n=>`<option>${esc(n)}</option>`).join("")}</select>
-      <button id="wk-new">New</button> <button id="wk-del">Delete</button>
-      <div><textarea id="wk-text" rows="12" style="width:100%"></textarea></div>
-      <button id="wk-save" class="primary">Save doc</button>
+      <div class="formrow">
+        <label class="f grow"><span class="lbl">Document</span>
+          <select id="wk-doc">${docs.map(n=>`<option>${esc(n)}</option>`).join("")}</select></label>
+        <button id="wk-new">New</button>
+        <button id="wk-del">Delete</button>
+      </div>
+      <textarea id="wk-text" rows="12" placeholder="${docs.length?"":"No documents yet - hit New to create one."}"></textarea>
+      <div class="actions"><button id="wk-save" class="primary">Save doc</button></div>
     </div>
     <div class="card"><h3>Profiles</h3>
-      <input id="wk-pname" placeholder="profile name">
-      <select id="wk-pdocs" multiple size="4">${docs.map(n=>`<option>${esc(n)}</option>`).join("")}</select>
-      <button id="wk-psave" class="primary">Save profile</button>
-      <div id="wk-plist" class="note">${Object.keys(profiles).map(esc).join(", ")||"(none)"}</div>
+      <div class="formrow">
+        <label class="f grow"><span class="lbl">Profile name</span>
+          <input id="wk-pname" placeholder="e.g. coding"></label>
+        <label class="f grow"><span class="lbl">Documents in profile</span>
+          ${docs.length
+            ? `<select id="wk-pdocs" multiple size="4">${docs.map(n=>`<option>${esc(n)}</option>`).join("")}</select>`
+            : `<select id="wk-pdocs" multiple size="4" disabled></select>`}</label>
+        <button id="wk-psave" class="primary">Save profile</button>
+      </div>
+      <div class="note">${docs.length?"Ctrl-click to select more than one.":"Create a context doc above first."}</div>
+      <div id="wk-plist" class="note">Saved: ${Object.keys(profiles).map(esc).join(", ")||"(none)"}</div>
     </div>
     <div class="card"><h3>Active profile per model</h3>
-      <select id="wk-model">${ids.map(m=>`<option>${esc(m)}</option>`).join("")}</select>
-      <select id="wk-active"><option value="">(none)</option>${Object.keys(profiles).map(n=>`<option>${esc(n)}</option>`).join("")}</select>
-      <button id="wk-setactive">Set active</button>
+      <div class="formrow">
+        <label class="f grow"><span class="lbl">Model</span>
+          <select id="wk-model">${ids.map(m=>`<option>${esc(m)}</option>`).join("")}</select></label>
+        <label class="f grow"><span class="lbl">Profile</span>
+          <select id="wk-active"><option value="">(none)</option>${Object.keys(profiles).map(n=>`<option>${esc(n)}</option>`).join("")}</select></label>
+        <button id="wk-setactive">Set active</button>
+      </div>
     </div>
     <div class="card"><h3>Export to agent file</h3>
-      <select id="wk-eagent"><option value="claude-code">Claude Code (CLAUDE.md)</option><option value="codex">Codex (AGENTS.md)</option><option value="pi">pi.dev (AGENTS.md)</option></select>
-      <select id="wk-eprofile">${Object.keys(profiles).map(n=>`<option>${esc(n)}</option>`).join("")}</select>
-      <input id="wk-epath" placeholder="(optional) project path; blank = global">
-      <button id="wk-export">Export</button>
+      <div class="formrow">
+        <label class="f grow"><span class="lbl">Agent</span>
+          <select id="wk-eagent"><option value="claude-code">Claude Code (CLAUDE.md)</option><option value="codex">Codex (AGENTS.md)</option><option value="pi">pi.dev (AGENTS.md)</option></select></label>
+        <label class="f grow"><span class="lbl">Profile</span>
+          <select id="wk-eprofile">${Object.keys(profiles).map(n=>`<option>${esc(n)}</option>`).join("")}</select></label>
+        <label class="f grow"><span class="lbl">Project path</span>
+          <input id="wk-epath" placeholder="(optional) blank = global"></label>
+        <button id="wk-export">Export</button>
+      </div>
     </div>`);
   const load = async () => {
     const n = $("#wk-doc").value;

--- a/web/js/context.js
+++ b/web/js/context.js
@@ -1,11 +1,19 @@
 // Context tab: markdown context docs, named profiles composed from them, the
 // per-model active profile, and export into an agent's CLAUDE.md / AGENTS.md.
 import { $, esc, setHTML, api, toast } from "./core.js";
-import { models } from "./state.js";
+import { S, models } from "./state.js";
 
 export async function loadContext() {
   const v = $("#view-context");
-  const [d, pr] = await Promise.all([api("/api/wiki/docs"), api("/api/wiki/profiles")]);
+  // Deep-linking straight to #context renders before the first /api/state poll
+  // lands, which left "Active profile per model" with an empty dropdown and no
+  // way to set anything until you visited another tab. Fetch state ourselves
+  // when it isn't there yet rather than rendering a knowingly empty control.
+  const [d, pr] = await Promise.all([
+    api("/api/wiki/docs"),
+    api("/api/wiki/profiles"),
+    S.STATE ? null : api("/api/state").then(s => { if (s && !s.error) S.STATE = s; }),
+  ]);
   const docs = d.docs || [], profiles = pr.profiles || {};
   const ids = models().map(m => m.id);
   setHTML(v, `

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -5,7 +5,7 @@
 // There are no `window`-assigned globals: every handler is wired with
 // addEventListener (toolbar controls by id, dynamic rows by delegation), so the
 // HTML and view templates carry no inline on* attributes to keep in sync.
-import { $, api } from "./core.js";
+import { $, api, esc, setHTML } from "./core.js";
 import { S } from "./state.js";
 import * as ui from "./ui.js";
 import * as models from "./models.js";
@@ -48,9 +48,29 @@ window.addEventListener("hashchange", () => {
 });
 if (location.hash) ui.switchTab(location.hash.slice(1));
 
+// The engine badge sits beside the clock but changes about once a session,
+// so it gets its own element: the clock stays a textContent write, and the
+// badge is only re-rendered (through the audited setHTML/esc sink) when the
+// engine actually changes. Rebuilding markup once a second would both churn
+// the DOM and put a dynamic value into innerHTML on every tick.
+const ENGINE_LABEL = { llamacpp: "llama.cpp", ikllama: "ik_llama" };
+let shownEngine = null;
+
+function renderEngineBadge() {
+  const engine = (S.STATE && S.STATE.active_engine) || "";
+  if (engine === shownEngine) return;
+  shownEngine = engine;
+  const el = $("#engine-badge");
+  if (!el) return;
+  setHTML(el, engine
+    ? `<span class="tag be-${esc(engine)}">${esc(ENGINE_LABEL[engine] || engine)}</span>`
+    : "");
+}
+
 function clock() {
   const el = $("#clock");
   if (el) el.textContent = new Date().toLocaleTimeString("en-GB") + " LOCAL";
+  renderEngineBadge();
 }
 clock();
 setInterval(clock, 1000);

--- a/web/js/models.js
+++ b/web/js/models.js
@@ -194,13 +194,25 @@ function shownModels() {
     .filter(m => (!mquery || m.id.toLowerCase().includes(mquery)) && (!favOnly || favs.has(m.id)))
     .sort((a, b) => (favs.has(b.id)?1:0) - (favs.has(a.id)?1:0));
 }
-function rowHead(m) {
+const BACKEND_LABEL = { vllm: "vLLM", ikllama: "ik_llama", llamacpp: "llama.cpp" };
+
+// The engine tag only carries information when more than one engine is serving
+// models. On a llama.cpp-only install it was 15 identical LLAMA.CPP tags - pure
+// noise competing with the id for attention.
+function backendTagNeeded() {
+  return new Set(modelRows().map(m => m.backend || "llamacpp")).size > 1;
+}
+
+function rowHead(m, showBackend) {
   const vis = m.modalities.includes("image"), loaded = m.status === "loaded", isFav = favs.has(m.id);
   const stuckSecs = loadingSecs(m);
+  const be = m.backend || "llamacpp";
+  const beTag = showBackend
+    ? `<span class="tag be-${esc(be)}">${esc(BACKEND_LABEL[be] || be)}</span>` : "";
   return `${compareMode?`<input type="checkbox" class="cmp" data-cmp="${esc(m.id)}" ${cmpSet.has(m.id)?"checked":""} title="pick to compare">`:""}
         <span class="led ${loaded?"loaded":""} ${m.failed?"failed":""}"></span>
         <span class="fav ${isFav?"on":""}" data-fav="${esc(m.id)}" title="${isFav?"unfavorite":"favorite"}">&starf;</span>
-        <span class="mid">${esc(m.id)}<span class="tag be-${esc(m.backend||'llamacpp')}">${m.backend==='vllm'?'vLLM':(m.backend==='ikllama'?'ik_llama':'llama.cpp')}</span>${vis?'<span class="tag vis">vision</span>':''}${!m.in_ini?'<span class="tag">auto</span>':''}${m.endpoint?`<span class="tag ep" data-ep="${esc(m.endpoint)}" title="click to copy endpoint">${esc(m.endpoint.replace('http://',''))}</span>`:''}</span>
+        <span class="mid" title="${esc(m.id)}">${esc(m.id)}${beTag}${vis?'<span class="tag vis">vision</span>':''}${!m.in_ini?'<span class="tag">auto</span>':''}${m.endpoint?`<span class="tag ep" data-ep="${esc(m.endpoint)}" title="click to copy endpoint">${esc(m.endpoint.replace('http://',''))}</span>`:''}</span>
         <span class="ctxpill"><span class="k">CTX</span> ${esc(m.eff_ctx)}</span>
         <span class="stat ${loaded?"loaded":""}" style="${stuckSecs>=20?"color:var(--red)":""}">${m.failed?"FAILED":esc(m.status)}${stuckSecs>=20?` (${stuckSecs}s, check log)`:""}</span>
         ${quickBtn(m)}
@@ -208,10 +220,10 @@ function rowHead(m) {
 }
 // Everything rowHead() reads. Compared as a string so an unchanged row is left
 // in the DOM untouched - which is what keeps focus, selection and scroll alive.
-function headSig(m, cols) {
+function headSig(m, cols, showBackend) {
   return JSON.stringify([m.id, m.status, m.failed, m.backend, m.endpoint, m.eff_ctx,
     m.modalities, m.in_ini, favs.has(m.id), compareMode, cmpSet.has(m.id),
-    loadQ.findIndex(j => j.id === m.id), loadingSecs(m) >= 20, cols]);
+    loadQ.findIndex(j => j.id === m.id), loadingSecs(m) >= 20, cols, showBackend]);
 }
 // Keyed so only a different model, backend or schema rebuilds the knob grid.
 function knobSig(m) {
@@ -231,6 +243,7 @@ export function renderModels() {
   document.title = nLoaded ? `▸${nLoaded} LLAMAFORGE` : "LLAMAFORGE";
   const cols = compareMode ? "16px 14px 18px 1fr auto auto auto auto"
                            : "14px 18px 1fr auto auto auto auto";
+  const showBackend = backendTagNeeded();
   const list = $("#list");
   if (!list) return;
   if (!ms.length) { setHTML(list, `<div class="skel">NO MODELS MATCH</div>`); return; }
@@ -247,11 +260,11 @@ export function renderModels() {
       row.innerHTML = `<div class="rhead"></div><div class="edit"></div>`;
     } else existing.delete(m.id);
 
-    const hs = headSig(m, cols);
+    const hs = headSig(m, cols, showBackend);
     if (row._hs !== hs) {
       const head = row.firstElementChild;
       head.style.gridTemplateColumns = cols;
-      setHTML(head, rowHead(m));
+      setHTML(head, rowHead(m, showBackend));
       row._hs = hs;
     }
     row.classList.toggle("open", m.id === openId);

--- a/web/js/models.js
+++ b/web/js/models.js
@@ -200,7 +200,7 @@ function rowHead(m) {
   return `${compareMode?`<input type="checkbox" class="cmp" data-cmp="${esc(m.id)}" ${cmpSet.has(m.id)?"checked":""} title="pick to compare">`:""}
         <span class="led ${loaded?"loaded":""} ${m.failed?"failed":""}"></span>
         <span class="fav ${isFav?"on":""}" data-fav="${esc(m.id)}" title="${isFav?"unfavorite":"favorite"}">&starf;</span>
-        <span class="mid">${esc(m.id)}<span class="tag be-${esc(m.backend||'llamacpp')}">${(m.backend==='vllm')?'vLLM':'llama.cpp'}</span>${vis?'<span class="tag vis">vision</span>':''}${!m.in_ini?'<span class="tag">auto</span>':''}${m.endpoint?`<span class="tag ep" data-ep="${esc(m.endpoint)}" title="click to copy endpoint">${esc(m.endpoint.replace('http://',''))}</span>`:''}</span>
+        <span class="mid">${esc(m.id)}<span class="tag be-${esc(m.backend||'llamacpp')}">${m.backend==='vllm'?'vLLM':(m.backend==='ikllama'?'ik_llama':'llama.cpp')}</span>${vis?'<span class="tag vis">vision</span>':''}${!m.in_ini?'<span class="tag">auto</span>':''}${m.endpoint?`<span class="tag ep" data-ep="${esc(m.endpoint)}" title="click to copy endpoint">${esc(m.endpoint.replace('http://',''))}</span>`:''}</span>
         <span class="ctxpill"><span class="k">CTX</span> ${esc(m.eff_ctx)}</span>
         <span class="stat ${loaded?"loaded":""}" style="${stuckSecs>=20?"color:var(--red)":""}">${m.failed?"FAILED":esc(m.status)}${stuckSecs>=20?` (${stuckSecs}s, check log)`:""}</span>
         ${quickBtn(m)}


### PR DESCRIPTION
## The load failure

Two things in `models.ini`, only one of which was an agent's doing:

- `split-mode = row` — **not a valid mode in this llama.cpp build.** Its `--help`
  lists only `none | graph | layer`; `row` is the old name the parser still
  accepts but CUDA then rejects with `device CUDA0 does not support split
  buffers`, so the child exits 1. (Worth knowing: `graph` is documented but the
  parser rejects it, so this build's help and its argument parser disagree.)
- A missing per-model `ctx-size`, which made the model inherit `[*] ctx-size =
  150000` and OOM on compute buffers.

The second one was **ours**. `apply_ctx_defaults()` runs on every panel startup
and deleted any per-model `ctx-size` whenever the model's GGUF trained length
reached the global, on the theory that it could "inherit the global". A trained
length is not a VRAM budget — a 27B Q6_K that trains to 262144 still OOMs at
150000 with an MTP draft context — so this silently reimposed a config that
could not load, every restart. It now fills a gap or clamps an over-extension
and never overrules a value that is already there.

## ik_llama

The integration is landed with its bugs fixed, but **it cannot currently be the
router**, and the switch now says so instead of breaking things:

- Dependency injection restored: `available()` and `Registry.state()` read
  through injected deps instead of `config.load()`, so tests stop consulting
  whatever `config.json` the developer happens to have.
- `active_engine` is validated; an unexpected value degrades to `llamacpp`
  rather than raising `KeyError` out of `/api/state`, which polls constantly and
  would have blanked the dashboard.
- Both llama-family engines drive the same router, so a model is listed once
  rather than once per engine, and a stale `ikllama` hint from an already-open
  tab no longer edits knobs against the wrong binary's schema.
- `post_engine_switch` validates *before* persisting, and refuses a binary with
  no router mode. ik_llama forked before router mode and answers `unknown
  argument: --models-preset`; switching to it used to persist `active_engine`
  and then leave the machine with no router.
- `ini_path()` and `run.ps1` use `splitext`/`[IO.Path]` instead of
  `str.replace(".ini", ...)`, which is a global replace that mangled any parent
  directory containing `.ini`.
- `ik_llama_*` path defaults ship empty like every other path default rather
  than hardcoding one machine's `D:/` layout.

Making ik_llama usable means the process-managed treatment vLLM already has
(one model per process), not the router path. That is a feature and is left for
its own change.

## UI

A sweep of all eight tabs found one root cause behind most of it: the only input
rule was `.fld input, .fld select`, scoped to a wrapper class, so any control
outside a `.fld` fell through to the browser default — a white box on a black
terminal UI — and `textarea` was never styled at all.

- Style `input`/`select`/`textarea` themselves; `.fld` now only adds layout.
  Checkboxes keep their native box, tinted with `accent-color`.
- Context laid out bare inline controls; it gets a labelled scaffold and real
  empty states, and no longer races `/api/state` on a deep link (its model
  dropdown was empty until you visited another tab).
- The three "empty boxes" at the foot of the sidebar were icons all along:
  `.sicon` inherits `button{padding:9px 16px}`, and with the global `border-box`
  a 34px button leaves 2px of content box.
- The credit line no longer floats mid-page on short tabs.
- The per-row engine tag only appears when more than one engine is serving
  models — it was fifteen identical `LLAMA.CPP` tags drowning out `VISION`.
- Long model ids wrap on narrow viewports instead of ellipsing three different
  gemma-4 models down to the same string.

## Verification

- **373 tests pass** (was 347 with 1 failing). New coverage for
  `apply_ctx_defaults`, the engine switch, ini-path derivation, and router-mode
  capability — none of which had any.
- Model loads and serves through the real router; the refused engine switch
  leaves `active_engine` and the router untouched.
- Chrome headless across the tabs: no console errors, and instrumented for
  horizontal overflow at every viewport width (none).