### PR TITLE
Fix first-run blockers; add preset binding, MTP auto-wire, offload-aware fit, partial-build reporting

### DIFF
--- a/backend/builder.py
+++ b/backend/builder.py
@@ -157,7 +157,7 @@ class BuildManager:
             if self.state["running"]:
                 return
             self.state.update(running=True, phase="starting", returncode=None,
-                              started=time.time(), finished=None)
+                              started=time.time(), finished=None, warning=None)
         open(self.log_path, "w").close()  # fresh log
         try:
             bad = self.validate_paths(src, build_dir)
@@ -189,27 +189,63 @@ class BuildManager:
             rc = self._stream(["cmake", "--build", build_dir, "--config", "Release",
                                "--parallel", str(jobs)])
             if rc != 0:
-                raise RuntimeError("cmake build failed")
+                # cmake returns one code for the whole build. A non-essential
+                # later target (npm/sharp UI assets) can fail after llama-server
+                # already built - reporting BUILD FAILED then is wrong. But only
+                # a binary from THIS run counts: a stale one from a previous
+                # success would hide a real compile failure, so freshness is
+                # proven by mtime, not assumed from mere presence.
+                fresh = self._fresh_binary(build_dir, self.state.get("started") or 0)
+                if not fresh:
+                    raise RuntimeError("cmake build failed")
+                self.state.update(phase="done_warnings", returncode=0,
+                                  warning="llama-server built, but a later build "
+                                          "step failed - see the log.")
+                self._log("\n=== BUILD OK (with warnings) ===")
+                self._record_built(fresh)
+                return
 
             self.state.update(phase="done", returncode=0)
             self._log("\n=== BUILD OK ===")
             found = self.locate_server_bin(build_dir)
             if found:
-                self.state["server_bin"] = found
-                self._log(f"[binaries] llama-server -> {found}")
-                try:
-                    if self.on_built:
-                        self.on_built(found)
-                except Exception as e:
-                    # Recording the path is a convenience; the build itself
-                    # succeeded and must not be reported as failed over this.
-                    self._log(f"[binaries] could not record server_bin: {e}")
+                self._record_built(found)
         except Exception as e:
             self.state.update(phase="failed", returncode=1)
             self._log(f"\n=== BUILD FAILED: {e} ===")
         finally:
             self.state.update(running=False, finished=time.time())
             self._upd_cache.clear()   # a pull may have moved HEAD; re-check next open
+
+    # Filesystem mtime granularity is coarse (up to ~2s on FAT; truncation can
+    # even put a just-written file's recorded mtime a hair below the wall-clock
+    # time captured moments earlier). A stale binary is from a *previous* build -
+    # minutes or more old - so this tolerance separates "made this run" from
+    # "left over" without ever misreading a genuinely fresh binary as stale.
+    _MTIME_TOLERANCE = 3.0
+
+    def _fresh_binary(self, build_dir, since):
+        """The built llama-server if it exists AND was (re)written by this run,
+        else None. Distinguishes a binary this build produced from a stale one
+        left by a previous successful build."""
+        p = self.locate_server_bin(build_dir)
+        if not p:
+            return None
+        try:
+            return p if os.path.getmtime(p) >= since - self._MTIME_TOLERANCE else None
+        except OSError:
+            return None
+
+    def _record_built(self, found):
+        """Note the built binary in state and hand it to on_built. A raising
+        callback (e.g. read-only config.json) must never fail a good build."""
+        self.state["server_bin"] = found
+        self._log(f"[binaries] llama-server -> {found}")
+        try:
+            if self.on_built:
+                self.on_built(found)
+        except Exception as e:
+            self._log(f"[binaries] could not record server_bin: {e}")
 
     def start(self, src, build_dir, flags, pull=True, jobs=None):
         if self.state["running"]:

--- a/backend/builder.py
+++ b/backend/builder.py
@@ -9,7 +9,12 @@ UPDATE_TTL      = 900   # seconds a successful upstream check stays cached
 UPDATE_TTL_FAIL = 60    # failed fetches retry sooner, but never per-click
 
 class BuildManager:
-    def __init__(self, log_dir, log_name="build"):
+    def __init__(self, log_dir, log_name="build", on_built=None):
+        # on_built(path) fires once, after a successful build, with the located
+        # llama-server. Injected rather than imported so builder.py stays free of
+        # config.py: one BuildManager exists per engine and only the caller knows
+        # which config key a given instance owns.
+        self.on_built = on_built
         self.log_dir = log_dir
         os.makedirs(log_dir, exist_ok=True)
         self.log_path = os.path.join(log_dir, f"{log_name}.log")
@@ -84,6 +89,48 @@ class BuildManager:
         flat = os.path.join(build_dir, "bin")
         return flat if isdir(flat) else None
 
+    @staticmethod
+    def locate_server_bin(build_dir, isdir=os.path.isdir, isfile=os.path.isfile):
+        """Where this build actually put llama-server, or None.
+
+        bootstrap has to guess this path before anything is built, and it guesses
+        the Ninja/Make layout (bin/llama-server). MSVC's multi-config generator
+        puts it in bin/Release with an .exe suffix instead, so on Windows the
+        guess was always wrong and had to be corrected by hand in config.json
+        after every build. Both names are probed rather than keying off the host
+        OS, so a cross-build or a WSL-built tree resolves the same way.
+        """
+        if not build_dir:
+            return None
+        d = BuildManager.binaries_dir(build_dir, isdir=isdir)
+        if not d:
+            return None
+        for name in ("llama-server.exe", "llama-server"):
+            p = os.path.join(d, name)
+            if isfile(p):
+                return p
+        return None
+
+    @staticmethod
+    def validate_paths(src, build_dir, isdir=os.path.isdir):
+        """Why the build can't run, or "" if it can.
+
+        On a fresh install llama_src/build_dir are deliberately blank, so Rebuild
+        used to run `cmake -B  -S ` and surface CMake's own "No build directory
+        specified for -B" - an error about our bug, phrased as if the user had
+        typed something wrong. Check here and say what's actually missing.
+
+        build_dir is not required to exist: cmake creates it. Only the source
+        tree has to be there already.
+        """
+        if not (src or "").strip():
+            return "llama.cpp source directory is not set - set it in Setup first."
+        if not (build_dir or "").strip():
+            return "Build directory is not set - set it in Setup first."
+        if not isdir(src):
+            return f"llama.cpp source directory does not exist: {src}"
+        return ""
+
     def backup_binaries(self, build_dir):
         src = self.binaries_dir(build_dir)
         if src:
@@ -113,6 +160,9 @@ class BuildManager:
                               started=time.time(), finished=None)
         open(self.log_path, "w").close()  # fresh log
         try:
+            bad = self.validate_paths(src, build_dir)
+            if bad:
+                raise RuntimeError(bad)
             if pull:
                 self.state["phase"] = "pull"
                 self._log("=== git pull (origin) ===")
@@ -143,6 +193,17 @@ class BuildManager:
 
             self.state.update(phase="done", returncode=0)
             self._log("\n=== BUILD OK ===")
+            found = self.locate_server_bin(build_dir)
+            if found:
+                self.state["server_bin"] = found
+                self._log(f"[binaries] llama-server -> {found}")
+                try:
+                    if self.on_built:
+                        self.on_built(found)
+                except Exception as e:
+                    # Recording the path is a convenience; the build itself
+                    # succeeded and must not be reported as failed over this.
+                    self._log(f"[binaries] could not record server_bin: {e}")
         except Exception as e:
             self.state.update(phase="failed", returncode=1)
             self._log(f"\n=== BUILD FAILED: {e} ===")

--- a/backend/config.py
+++ b/backend/config.py
@@ -47,6 +47,7 @@ DEFAULTS = {
     "active_engine": "llamacpp",              # which binary the router uses: llamacpp | ikllama
     "auto_load_model": "",                    # model id to load automatically on launch ("" = none)
     "presets":     {},                       # named knob sets: {name: {knob: value}}
+    "preset_bindings": {},                    # {model_id: preset_name} auto-applied on bind/edit
     "ui_mode":     "lite",                    # "lite" (curated knobs) or "advanced" (all ~220)
     "onboarded":   False,                     # first-run wizard shown once, then True
     "anthropic_default_model": "",           # fallback local model id for the Anthropic shim
@@ -338,16 +339,72 @@ def save_preset(name, settings):
         return presets
 
 def delete_preset(name):
-    """Remove a named preset. Returns True if it existed."""
+    """Remove a named preset and any model bindings that pointed at it. Returns
+    True if the preset existed."""
     with _LOCK:
         cfg = load()
         presets = cfg.get("presets")
-        if isinstance(presets, dict) and name in presets:
-            del presets[name]
-            cfg["presets"] = presets
+        if not (isinstance(presets, dict) and name in presets):
+            return False
+        del presets[name]
+        cfg["presets"] = presets
+        binds = cfg.get("preset_bindings")
+        if isinstance(binds, dict):
+            cfg["preset_bindings"] = {m: n for m, n in binds.items() if n != name}
+        save(cfg)
+        return True
+
+# ---------------- preset bindings ----------------
+# A binding names the preset a model defaults to. The knobs themselves are
+# materialized into models.ini by the caller (routes) at bind/edit time - config
+# only owns the mapping, because reloading the router is not config's job.
+
+def get_bindings():
+    b = load().get("preset_bindings")
+    return b if isinstance(b, dict) else {}
+
+def bind_preset(model_id, name):
+    """Bind model_id to preset `name` (or unbind when name is ""). Raises if the
+    preset does not exist. Returns the full bindings map."""
+    model_id = (model_id or "").strip()
+    if not model_id:
+        raise ValueError("model id is required")
+    name = (name or "").strip()
+    with _LOCK:
+        cfg = load()
+        binds = cfg.get("preset_bindings")
+        if not isinstance(binds, dict):
+            binds = {}
+        if name == "":
+            binds.pop(model_id, None)
+        else:
+            if name not in (cfg.get("presets") or {}):
+                raise ValueError(f"unknown preset: {name}")
+            binds[model_id] = name
+        cfg["preset_bindings"] = binds
+        save(cfg)
+        return binds
+
+def unbind_preset(model_id):
+    """Remove a model's binding. Returns True if it had one."""
+    with _LOCK:
+        cfg = load()
+        binds = cfg.get("preset_bindings")
+        if isinstance(binds, dict) and model_id in binds:
+            del binds[model_id]
+            cfg["preset_bindings"] = binds
             save(cfg)
             return True
         return False
+
+def prune_binding(model_id):
+    """Drop a deleted model's binding. Alias of unbind_preset for call-site
+    clarity."""
+    return unbind_preset(model_id)
+
+def bindings_for_preset(name):
+    """Model ids bound to preset `name`."""
+    return [m for m, n in get_bindings().items() if n == name]
 
 # ---------------- automatic ctx-size defaults ----------------
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -160,8 +160,14 @@ def migrate():
 # apply_ctx_defaults holds this one across many set_keys calls.
 _INI_LOCK = threading.RLock()
 
+# A Windows drive-letter (C:\ or C:/) or UNC (\\host) path. os.path.isabs() only
+# recognizes these when running ON Windows; a config.json written on a Windows
+# box is still absolute when its paths are read anywhere else (e.g. CI), so match
+# them directly rather than trust the host's path flavour.
+_WIN_ABS = re.compile(r"^[A-Za-z]:[\\/]|^\\\\|^//")
+
 def _abs(p):
-    """Anchor a configured path to the repo root.
+    """Anchor a configured path to the repo root, unless it is already absolute.
 
     The router is spawned detached and is handed this path as an argument, so it
     resolves any relative value against *its* CWD - whatever directory the user
@@ -169,10 +175,15 @@ def _abs(p):
     starting from anywhere but the repo root pointed llama-server at a different,
     usually nonexistent registry: it came up with 0 models and the dashboard
     looked like it had lost every model on restart.
+
+    "Absolute" spans both path flavours on purpose: re-rooting a Windows user's
+    "D:/models.ini" because the host happens to be POSIX would corrupt it.
     """
     if not p:
         return p
-    return p if os.path.isabs(p) else os.path.normpath(os.path.join(ROOT, p))
+    if os.path.isabs(p) or _WIN_ABS.match(p):
+        return p
+    return os.path.normpath(os.path.join(ROOT, p))
 
 def ini_path():
     """The models.ini the active engine reads, always as an absolute path.

--- a/backend/config.py
+++ b/backend/config.py
@@ -159,8 +159,22 @@ def migrate():
 # apply_ctx_defaults holds this one across many set_keys calls.
 _INI_LOCK = threading.RLock()
 
+def _abs(p):
+    """Anchor a configured path to the repo root.
+
+    The router is spawned detached and is handed this path as an argument, so it
+    resolves any relative value against *its* CWD - whatever directory the user
+    launched the panel from. config.example.json ships "./models.ini", so
+    starting from anywhere but the repo root pointed llama-server at a different,
+    usually nonexistent registry: it came up with 0 models and the dashboard
+    looked like it had lost every model on restart.
+    """
+    if not p:
+        return p
+    return p if os.path.isabs(p) else os.path.normpath(os.path.join(ROOT, p))
+
 def ini_path():
-    """The models.ini the active engine reads.
+    """The models.ini the active engine reads, always as an absolute path.
 
     ik_llama gets its own registry because the two binaries accept different
     knobs; when the user has not named one, derive a sibling of the llama.cpp
@@ -170,10 +184,10 @@ def ini_path():
     if c.get("active_engine") == "ikllama":
         p = c.get("ik_llama_models_ini")
         if p:
-            return p
-        stem, ext = os.path.splitext(c["models_ini"])
+            return _abs(p)
+        stem, ext = os.path.splitext(_abs(c["models_ini"]))
         return stem + "-ikllama" + (ext or ".ini")
-    return c["models_ini"]
+    return _abs(c["models_ini"])
 
 def read_sections(path=None):
     """Return {section: {key: value}} for all sections including [*]."""
@@ -399,13 +413,27 @@ def apply_ctx_defaults(path=None):
                 changed.append(sec)
         return {"changed": changed}
 
-def ensure_global(defaults, path=None):
-    """Make sure a [*] global section exists with sane defaults (first run)."""
+def ensure_models_ini(path=None, defaults=None):
+    """Create models.ini with a [*] global section if it isn't there yet.
+
+    llama-server refuses to start without this file, and on a fresh checkout
+    nothing created it: the repo ships no models.ini (it's per-machine), so the
+    very first launch failed with a bind-less router and an empty dashboard.
+    Runs on every startup and is idempotent - an existing file, even one with no
+    [*] section, is left exactly as the user wrote it.
+
+    Returns True if the file was created.
+    """
     path = path or ini_path()
     with _INI_LOCK:
-        secs = read_sections(path)
-        if "*" not in secs:
-            if not os.path.exists(path):
-                with open(path, "w", encoding="utf-8", newline="") as f:
-                    f.write("version = 1\n")
-            _set_keys_locked("*", defaults, path)
+        if os.path.exists(path):
+            return False
+        parent = os.path.dirname(path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(path, "w", encoding="utf-8", newline="") as f:
+            f.write("; LlamaForge model registry - read by llama-server's router.\n"
+                    "; Sections are model ids; keys are llama-server flags.\n"
+                    "version = 1\n")
+        _set_keys_locked("*", defaults or {"ctx-size": CTX_GLOBAL_DEFAULT}, path)
+        return True

--- a/backend/gguf.py
+++ b/backend/gguf.py
@@ -91,6 +91,35 @@ def context_length(path):
         return None
 
 
+def has_nextn(path):
+    """True if this GGUF declares MTP/NextN layers (`*.nextn_predict_layers` > 0).
+
+    llama.cpp gates draft-mtp speculative decoding on NextN layers being present
+    in the model, not on the arch name, so this file-intrinsic signal is what
+    decides whether an mtp-* sidecar can actually be enabled. The curated
+    metadata() drops this key, hence a dedicated raw-KV walk. Never raises.
+    """
+    try:
+        with open(path, "rb") as f:
+            if _rd(f, 4) != b"GGUF":
+                return False
+            if _u32(f) < 2:
+                return False
+            _u64(f)                       # tensor count (unused)
+            n_kv = _u64(f)
+            if n_kv > 1_000_000:
+                return False
+            for _ in range(n_kv):
+                key = _read_str(f)
+                vt  = _u32(f)
+                if key.endswith(".nextn_predict_layers") and vt in _INT_TYPES:
+                    return int(_read_scalar(f, vt)) > 0
+                _skip_value(f, vt)
+            return False
+    except Exception:
+        return False
+
+
 # general.file_type is an LLAMA_FTYPE enum; map the common quant tiers to labels.
 _FTYPE = {
     0: "F32", 1: "F16", 2: "Q4_0", 3: "Q4_1", 7: "Q8_0", 8: "Q5_0", 9: "Q5_1",

--- a/backend/osplat.py
+++ b/backend/osplat.py
@@ -176,3 +176,48 @@ def linux_install_hint(pm, package):
     return {"apt-get": f"sudo apt-get install -y {package}",
             "dnf": f"sudo dnf install -y {package}",
             "pacman": f"sudo pacman -S --noconfirm {package}"}.get(pm, "")
+
+
+def refresh_path():
+    """Re-read the machine PATH so a just-installed tool is visible right away.
+
+    winget/choco write PATH into the registry and broadcast WM_SETTINGCHANGE,
+    but this process inherited its copy of the environment at launch, so
+    shutil.which() kept reporting a freshly installed ninja as MISSING until
+    LlamaForge was restarted. Windows keeps the authoritative value in the
+    registry: read it back and merge it in, keeping anything this process added
+    itself (venv/activate prepends, test shims) ahead of the registry entries.
+
+    POSIX package managers install into directories that are already on PATH, so
+    there is nothing to refresh. Returns True if PATH gained any entries.
+    """
+    if not IS_WIN:
+        return False
+    try:
+        import winreg
+    except ImportError:                      # non-CPython / stripped install
+        return False
+    found = []
+    for hive, sub in ((winreg.HKEY_LOCAL_MACHINE,
+                       r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment"),
+                      (winreg.HKEY_CURRENT_USER, "Environment")):
+        try:
+            with winreg.OpenKey(hive, sub) as key:
+                raw, _ = winreg.QueryValueEx(key, "Path")
+        except OSError:                      # key or value absent; the other may still work
+            continue
+        found += [os.path.expandvars(p) for p in str(raw).split(os.pathsep) if p.strip()]
+    if not found:
+        return False
+    current_entries = [p for p in os.environ.get("PATH", "").split(os.pathsep) if p]
+    seen = {p.lower().rstrip("\\/") for p in current_entries}
+    added = []
+    for p in found:
+        key = p.lower().rstrip("\\/")
+        if key not in seen:
+            seen.add(key)
+            added.append(p)
+    if not added:
+        return False
+    os.environ["PATH"] = os.pathsep.join(current_entries + added)
+    return True

--- a/backend/prereqs.py
+++ b/backend/prereqs.py
@@ -142,6 +142,21 @@ def status():
         "platform": osplat.current(),
     }
 
+def _post_install(spec, log):
+    """Make a just-installed tool visible without restarting, and say so plainly
+    when it still isn't.
+
+    The Setup tab kept showing a successfully installed ninja as MISSING: winget
+    updates the registry PATH, but _which() reads the PATH this process
+    inherited at launch. Refresh from the registry, re-probe, and only ask for a
+    restart if that genuinely wasn't enough.
+    """
+    osplat.refresh_path()
+    if _tool_exe(spec):
+        return True, log
+    return True, (log + "\n\nInstalled, but not on this process's PATH yet - "
+                        "restart LlamaForge for it to be detected.")
+
 def install(name):
     """Install one tool by name. Returns (ok, log)."""
     spec = TOOLS.get(name)
@@ -151,8 +166,9 @@ def install(name):
         if not _which("brew"):
             return False, f"Homebrew not found. Install it (https://brew.sh) or manually: {spec['url']}"
         r = subprocess.run(["brew", "install", spec["brew"]], capture_output=True, text=True)
-        return (r.returncode == 0,
-                (r.stdout + r.stderr) or ("installed via brew" if r.returncode == 0 else "brew failed"))
+        if r.returncode == 0:
+            return _post_install(spec, (r.stdout + r.stderr) or "installed via brew")
+        return False, (r.stdout + r.stderr) or "brew failed"
     if osplat.IS_LINUX:
         hint = osplat.linux_install_hint(osplat.linux_pkg_manager(), spec["pkg"])
         return False, (f"Run this in a terminal (the dashboard never runs sudo):\n  {hint}"
@@ -162,7 +178,7 @@ def install(name):
                             "--accept-source-agreements", "--accept-package-agreements"],
                            capture_output=True, text=True)
         if r.returncode == 0:
-            return True, r.stdout or "installed via winget"
+            return _post_install(spec, r.stdout or "installed via winget")
         log = "winget failed:\n" + (r.stdout + r.stderr)
     else:
         log = "winget not available\n"
@@ -170,7 +186,7 @@ def install(name):
         r = subprocess.run(["choco", "install", spec["choco"], "-y"],
                            capture_output=True, text=True)
         if r.returncode == 0:
-            return True, log + "\ninstalled via choco"
+            return _post_install(spec, log + "\ninstalled via choco")
         return False, log + "\nchoco failed:\n" + (r.stdout + r.stderr)
     return False, log + f"\nNo package manager. Install manually: {spec['url']}"
 

--- a/backend/router_ctl.py
+++ b/backend/router_ctl.py
@@ -98,6 +98,14 @@ def stop(port, timeout=10):
 def start(server_bin, models_ini, port, host, api_key, logdir):
     if not server_bin or not os.path.exists(server_bin):
         return False, "server_bin not found - build llama.cpp first"
+    # Port 8080 is a popular default (XAMPP, Apache, other dev servers). Without
+    # this check we spawned llama-server anyway; it logged "couldn't bind HTTP
+    # server socket" into router.err.log and exited, while start() had already
+    # reported success - so the dashboard showed every model offline with no
+    # hint as to why. Ask before spawning, and name the port in the error.
+    if is_running(port):
+        return False, (f"port {port} is already in use by another process - "
+                       f"stop it, or change the router port in Setup")
     os.makedirs(logdir, exist_ok=True)
     args = [server_bin, "--models-preset", models_ini, "--models-max", "1", "--offline",
             "--host", host, "--port", str(port), "--metrics"]
@@ -107,8 +115,15 @@ def start(server_bin, models_ini, port, host, api_key, logdir):
     err = open(os.path.join(logdir, "router.err.log"), "a", encoding="utf-8", errors="replace")
     kw = ({"creationflags": CREATE_NO_WINDOW} if osplat.IS_WIN
           else {"start_new_session": True})   # detach from the dashboard's session
-    subprocess.Popen(args, stdout=out, stderr=err, stdin=subprocess.DEVNULL,
-                     close_fds=True, **kw)
+    try:
+        subprocess.Popen(args, stdout=out, stderr=err, stdin=subprocess.DEVNULL,
+                         close_fds=True, **kw)
+    finally:
+        # The child holds its own duplicated handles; these are the parent's
+        # copies and nothing reads them here. Leaving them open leaked two
+        # handles per restart for the life of the dashboard.
+        out.close()
+        err.close()
     return True, ""
 
 def restart(server_bin, models_ini, port, host, api_key, logdir):

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -33,8 +33,12 @@ VLLM_SUPPORTED = osplat.IS_WIN
 ROOT    = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 WEB     = os.path.join(ROOT, "web")
 LOGDIR  = os.path.join(ROOT, "logs")
-BUILDER_LLAMA   = BuildManager(LOGDIR, "build")
-BUILDER_IKLLAMA = BuildManager(LOGDIR, "build-ikllama")
+# Each engine records the binary its own build produced (see _record_server_bin).
+# Resolved at call time, so the helper can live further down with its siblings.
+BUILDER_LLAMA   = BuildManager(LOGDIR, "build",
+                               on_built=lambda p: _record_server_bin("server_bin", p))
+BUILDER_IKLLAMA = BuildManager(LOGDIR, "build-ikllama",
+                               on_built=lambda p: _record_server_bin("ik_llama_server_bin", p))
 
 def _builder_for(target):
     return BUILDER_IKLLAMA if target == "ikllama" else BUILDER_LLAMA
@@ -929,6 +933,12 @@ def post_build_start(req):
         bdir = c["build_dir"]
         flags = req.body.get("flags") or c.get("cmake_flags") or hardware.recommend()["cmake_flags"]
         config.update({"cmake_flags": flags})
+    # Answer an unset/bad path here rather than starting a build thread that can
+    # only fail: the user gets the reason in the UI instead of a raw cmake error
+    # in the build log ("No build directory specified for -B").
+    bad = BuildManager.validate_paths(src, bdir)
+    if bad:
+        return 200, {"started": False, "target": target, "error": bad}
     ok = builder.start(src, bdir, flags, pull=req.body.get("pull", True))
     return 200, {"started": ok, "target": target}
 
@@ -1152,6 +1162,23 @@ def _active_server_bin(c=None):
     if c.get("active_engine") == "ikllama":
         return c.get("ik_llama_server_bin", "")
     return c.get("server_bin", "")
+
+
+def _record_server_bin(key, path):
+    """Point `key` at the binary a finished build produced. Returns True if
+    config.json changed.
+
+    Only fills a gap or repairs a path that isn't there: bootstrap's pre-build
+    guess (`bin/llama-server`) never exists on MSVC, so it gets corrected, while
+    a path the user set deliberately - and that resolves - is left alone. This
+    runs on a build thread, so it goes through config.update()'s lock rather
+    than load/mutate/save.
+    """
+    current = (cfg().get(key) or "").strip()
+    if current and os.path.exists(current):
+        return False
+    config.update({key: path})
+    return True
 
 
 def post_network(req):

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -978,11 +978,21 @@ def post_scan(req):
 
 def post_scan_apply(req):
     entries = req.body.get("entries", [])
+    existing = config.read_sections()
     for e in entries:
         keys = {"model": e["model"]}
         # Always pass mmproj/embeddings so stale values are cleared on re-scan.
         keys["mmproj"] = e.get("mmproj") or None
         keys["embeddings"] = "true" if e.get("embeddings") else None
+        # MTP wiring is ADDITIVE, unlike mmproj: spec-type is also how the user
+        # selects ngram-* speculation, so clearing it on re-scan would wipe a
+        # hand-set mode. Only fill these when the section doesn't already carry
+        # its own value.
+        sect = existing.get(e["id"], {})
+        if e.get("draft_model") and not sect.get("spec-draft-model"):
+            keys["spec-draft-model"] = e["draft_model"]
+        if e.get("draft_mtp") and not sect.get("spec-type"):
+            keys["spec-type"] = "draft-mtp"
         config.set_keys(e["id"], keys)
     config.apply_ctx_defaults()
     router("/models?reload=1")

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -854,6 +854,8 @@ def post_model_delete(req):
         ok, err = backend.delete(mid)
     except backends.Unsupported as e:
         raise ApiError(400, str(e))
+    if ok:
+        config.prune_binding(mid)          # a gone model keeps no binding
     return (200 if ok else 500), {"ok": ok, "error": err, "backend": backend.name}
 
 
@@ -895,16 +897,37 @@ def post_autotune_refine(req):
 
 
 def post_presets_save(req):
+    name = req.body.get("name", "")
     try:
-        presets = config.save_preset(req.body.get("name", ""),
-                                     req.body.get("settings", {}))
+        presets = config.save_preset(name, req.body.get("settings", {}))
     except ValueError as e:
         raise ApiError(400, str(e))
+    # Re-sync every model bound to this preset: editing "coding" once updates
+    # all models using it - the point of binding (issue #2).
+    clean = _clean_settings(presets.get(name, {}))
+    for mid in config.bindings_for_preset(name):
+        _apply_knobs_and_reload(mid, clean)
     return 200, {"ok": True, "presets": presets}
 
 
 def post_presets_delete(req):
     return 200, {"ok": config.delete_preset(req.body.get("name", ""))}
+
+
+def post_presets_bind(req):
+    """Bind a preset as a model's default (name="" unbinds). Binding
+    materializes the preset's knobs into the model's section now; unbinding
+    leaves them in place - they're the user's once written."""
+    mid = req.body.get("model", "")
+    name = req.body.get("name", "")
+    try:
+        binds = config.bind_preset(mid, name)
+    except ValueError as e:
+        raise ApiError(400, str(e))
+    if name:
+        preset = config.get_presets().get(name, {})
+        _apply_knobs_and_reload(mid, _clean_settings(preset))
+    return 200, {"ok": True, "bindings": binds}
 
 
 def post_presets_apply(req):
@@ -1411,6 +1434,7 @@ POST_ROUTES = {
     "/api/autotune/recommend":  post_autotune_recommend,
     "/api/autotune/refine":     post_autotune_refine,
     "/api/presets/save":        post_presets_save,
+    "/api/presets/bind":        post_presets_bind,
     "/api/presets/delete":      post_presets_delete,
     "/api/presets/apply":       post_presets_apply,
     "/api/build/start":         post_build_start,

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -1041,6 +1041,11 @@ def post_hub_files(req):
                 f["predict"] = vram_predict.predict_remote(
                     repo=repo, gguf_file=f.get("path"), size_bytes=f.get("size"),
                     cfg=c, hw=hw)
+                # Prefer the offload-aware label over hub._fit()'s size-only
+                # guess; keep the naive value only when physics can't decide.
+                label = vram_predict.fit_label(f["predict"])
+                if label != "unknown":
+                    f["fit"] = label
         return 200, listing
     except Exception as e:
         return 200, {"error": str(e), "files": [], "mmproj": []}

--- a/backend/scanner.py
+++ b/backend/scanner.py
@@ -80,9 +80,12 @@ def _shard(p):
 def build_entries(paths):
     """Return list of {id, model, mmproj?, embeddings?, gib, existing_id?}."""
     mmproj_by_dir = {}
+    mtp_by_dir = {}
     for p in paths:
         if _is_mmproj(p):
             mmproj_by_dir[os.path.dirname(p)] = p
+        elif _is_mtp(p):
+            mtp_by_dir[os.path.dirname(p)] = p
 
     mains = []
     seen_shard_sets = set()
@@ -121,6 +124,15 @@ def build_entries(paths):
             arch = (metadata(p) or {}).get("architecture", "")
             if arch in _VISION_ARCHES:
                 e["mmproj"] = mm.replace("\\", "/")
+        # Attach an mtp-* sibling as a speculative draft model. Attaching alone
+        # is inert; only enable spec-type=draft-mtp when the sidecar actually
+        # declares NextN layers, the signal llama.cpp itself gates on.
+        mt = mtp_by_dir.get(os.path.dirname(p))
+        if mt:
+            from gguf import has_nextn
+            e["draft_model"] = mt.replace("\\", "/")
+            if has_nextn(mt):
+                e["draft_mtp"] = True
         if _is_embed(p):
             e["embeddings"] = True
         entries.append(e)

--- a/backend/server.py
+++ b/backend/server.py
@@ -324,6 +324,11 @@ def main():
     if config.LOAD_ERROR:
         print(f"  WARNING: {config.LOAD_ERROR}")
         print(f"  previous contents saved to {config.CONFIG}.corrupt")
+    try:                    # the repo ships no models.ini; llama-server needs one
+        if config.ensure_models_ini():
+            print(f"  created {config.ini_path()}")
+    except OSError as e:    # unwritable path: say so, the router will fail next
+        print(f"  WARNING: could not create models.ini ({e})")
     try:                    # backfill ctx-size defaults, then nudge the router
         if config.apply_ctx_defaults().get("changed"):
             routes.router("/models?reload=1")

--- a/backend/vram_predict.py
+++ b/backend/vram_predict.py
@@ -120,6 +120,32 @@ def _normalize(pred, confidence, source):
     }
 
 
+def fit_label(predict):
+    """Rate a model fits/tight/offload from a physics prediction, or "unknown".
+
+    Replaces hub._fit()'s size-only guess where a real prediction exists, so the
+    Discover fit badge stops contradicting the tok/s estimate beside it. The
+    reported failure was a large MoE (hybrid regime, experts on CPU) that runs
+    fine but got labelled "offload" purely for being bigger than VRAM. Here a
+    hybrid placement that is still interactive/usable reads as "tight", not
+    "offload"; only genuinely slow generation, or full disk streaming, is
+    "offload". Callers fall back to hub._fit() on "unknown".
+    """
+    if not predict or predict.get("confidence") == "unknown":
+        return "unknown"
+    regime = predict.get("regime")
+    use = predict.get("usability")
+    if regime is None or use is None:
+        return "unknown"
+    if use in ("slow", "impractical"):
+        return "offload"                 # too slow to matter, wherever it sits
+    if regime == "gpu-resident":
+        return "fits"
+    if regime == "hybrid":
+        return "tight"                   # partial offload but still usable (MoE sweet spot)
+    return "offload"                     # streaming from disk
+
+
 def _unknown(note):
     return {"regime": None, "tok_s": None, "usability": None,
             "gpu_resident_frac": 0.0,

--- a/run.ps1
+++ b/run.ps1
@@ -3,7 +3,23 @@
 # then opens the dashboard in your browser. Safe to run repeatedly.
 $ErrorActionPreference = "Stop"
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
-$cfg  = Get-Content (Join-Path $here "config.json") -Raw | ConvertFrom-Json
+
+# config.json is per-machine and deliberately not in the repo. Without this the
+# first run died on a raw "Get-Content: path does not exist" exception that said
+# nothing about config.example.json sitting right next to it.
+$cfgPath = Join-Path $here "config.json"
+if (-not (Test-Path $cfgPath)) {
+  $example = Join-Path $here "config.example.json"
+  if (-not (Test-Path $example)) {
+    Write-Host "config.json is missing and config.example.json was not found in $here." -ForegroundColor Red
+    Write-Host "Re-clone the repo, or create config.json by hand." -ForegroundColor Red
+    exit 1
+  }
+  Copy-Item $example $cfgPath
+  Write-Host "config.json not found - created one from config.example.json." -ForegroundColor Yellow
+  Write-Host "Set your llama.cpp paths and model folders in the dashboard's Setup tab." -ForegroundColor Yellow
+}
+$cfg = Get-Content $cfgPath -Raw | ConvertFrom-Json
 
 function Listening($port){ [bool](Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue) }
 
@@ -30,6 +46,25 @@ if (-not (Listening $cfg.router_port)) {
     $engineLabel = "llama.cpp"
     $modelsIni = $cfg.models_ini
   }
+  # Mirror config._abs(): the router is started without -WorkingDirectory, and
+  # config.example.json ships "./models.ini", so a relative value resolved
+  # against whatever directory the user ran this from - the router then read an
+  # empty registry and loaded 0 models.
+  if ($modelsIni -and -not [IO.Path]::IsPathRooted($modelsIni)) {
+    $modelsIni = [IO.Path]::GetFullPath((Join-Path $here $modelsIni))
+  }
+  # Mirror config.ensure_models_ini(): llama-server refuses to start without
+  # this file, and the router is launched here, before the backend can make one.
+  if ($modelsIni -and -not (Test-Path $modelsIni)) {
+    Set-Content -Path $modelsIni -Encoding utf8 -Value @(
+      "; LlamaForge model registry - read by llama-server's router.",
+      "; Sections are model ids; keys are llama-server flags.",
+      "version = 1",
+      "",
+      "[*]",
+      "ctx-size = 150000")
+    Write-Host "created $modelsIni"
+  }
   if (Test-Path $serverBin) {
     $routerHost = if ($cfg.router_host) { $cfg.router_host } else { "127.0.0.1" }
     $args = @("--models-preset", $modelsIni, "--models-max", "1", "--offline",
@@ -41,6 +76,17 @@ if (-not (Listening $cfg.router_port)) {
     Write-Host "started $engineLabel router on $($routerHost):$($cfg.router_port)"
   } else {
     Write-Host "server_bin not found ($serverBin) - open the dashboard Build tab to build $engineLabel first." -ForegroundColor Yellow
+  }
+} else {
+  # Something already holds the router port. If it isn't a llama-server, the
+  # dashboard would come up with every model "offline" and no stated reason -
+  # port 8080 collides with XAMPP/Apache and plenty of other dev servers.
+  $ownerPid = Get-NetTCPConnection -LocalPort $cfg.router_port -State Listen -ErrorAction SilentlyContinue |
+              Select-Object -First 1 -ExpandProperty OwningProcess
+  $ownerName = if ($ownerPid) { (Get-Process -Id $ownerPid -ErrorAction SilentlyContinue).ProcessName }
+  if ($ownerName -and $ownerName -notmatch "llama") {
+    Write-Host "port $($cfg.router_port) is already in use by '$ownerName' (PID $ownerPid)." -ForegroundColor Yellow
+    Write-Host "The router was not started. Stop that process, or change router_port in the Setup tab." -ForegroundColor Yellow
   }
 }
 

--- a/run.sh
+++ b/run.sh
@@ -6,6 +6,20 @@ set -e
 here="$(cd "$(dirname "$0")" && pwd)"
 cfg="$here/config.json"
 
+# config.json is per-machine and deliberately not in the repo. Without this the
+# first run died on a raw Python traceback from getcfg that said nothing about
+# config.example.json sitting right next to it.
+if [ ! -f "$cfg" ]; then
+  if [ ! -f "$here/config.example.json" ]; then
+    echo "config.json is missing and config.example.json was not found in $here." >&2
+    echo "Re-clone the repo, or create config.json by hand." >&2
+    exit 1
+  fi
+  cp "$here/config.example.json" "$cfg"
+  echo "config.json not found - created one from config.example.json."
+  echo "Set your llama.cpp paths and model folders in the dashboard's Setup tab."
+fi
+
 getcfg() { python3 -c "import json;print(json.load(open('$cfg')).get('$1',''))"; }
 
 listening() { lsof -ti "tcp:$1" -sTCP:LISTEN >/dev/null 2>&1; }
@@ -17,8 +31,32 @@ models_ini="$(getcfg models_ini)"
 router_host="$(getcfg router_host)"; [ -n "$router_host" ] || router_host=127.0.0.1
 api_key="$(getcfg router_api_key)"
 
+# Mirror config._abs(): the router inherits this shell's CWD, and
+# config.example.json ships "./models.ini", so a relative value resolved against
+# wherever the user ran this from - the router read an empty registry and loaded
+# 0 models.
+case "$models_ini" in
+  /*|"") ;;
+  *) models_ini="$here/${models_ini#./}" ;;
+esac
+
 logdir="$here/logs"
 mkdir -p "$logdir"
+
+# Mirror config.ensure_models_ini(): llama-server refuses to start without this
+# file, and the router is launched here, before the backend can make one.
+if [ -n "$models_ini" ] && [ ! -f "$models_ini" ]; then
+  mkdir -p "$(dirname "$models_ini")"
+  cat >"$models_ini" <<'EOF'
+; LlamaForge model registry - read by llama-server's router.
+; Sections are model ids; keys are llama-server flags.
+version = 1
+
+[*]
+ctx-size = 150000
+EOF
+  echo "created $models_ini"
+fi
 
 # 1. llama.cpp router (only if not already up)
 if ! listening "$router_port"; then
@@ -32,6 +70,16 @@ if ! listening "$router_port"; then
   else
     echo "server_bin not found ($server_bin) - open the dashboard Build tab to build llama.cpp first."
   fi
+else
+  # Something already holds the router port. If it isn't a llama-server, the
+  # dashboard would come up with every model "offline" and no stated reason.
+  owner="$(lsof -ti "tcp:$router_port" -sTCP:LISTEN 2>/dev/null | head -1)"
+  owner_name="$(ps -p "${owner:-0}" -o comm= 2>/dev/null || true)"
+  case "$owner_name" in
+    *llama*|"") ;;
+    *) echo "port $router_port is already in use by '$owner_name' (PID $owner)."
+       echo "The router was not started. Stop that process, or change router_port in the Setup tab." ;;
+  esac
 fi
 
 # 2. LlamaForge backend (dashboard)

--- a/tests/test_build_partial.py
+++ b/tests/test_build_partial.py
@@ -1,0 +1,104 @@
+"""Partial build success (issue #5 item 5).
+
+The llama.cpp UI-asset step (npm/sharp) can fail while llama-server itself
+builds. cmake returns one exit code for the whole build, so LlamaForge reported
+BUILD FAILED even though the binary was there. Report "built, with warnings" -
+but only when the binary is genuinely from THIS build, never a stale one from a
+previous success (which would hide a real compile failure).
+"""
+import conftest_paths  # noqa: F401
+import os, tempfile, time, unittest
+
+from builder import BuildManager
+
+
+def _touch(path, mtime=None):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write("")
+    if mtime is not None:
+        os.utime(path, (mtime, mtime))
+    return path
+
+
+class PartialBuildTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.src = os.path.join(self.tmp, "src")
+        self.build = os.path.join(self.tmp, "build")
+        os.makedirs(self.src)
+        self.built = []
+        self.bm = BuildManager(os.path.join(self.tmp, "logs"),
+                               on_built=self.built.append)
+
+    def _stub(self, build_rc, on_build_step=None):
+        """Make _stream succeed for every phase except the build step, which
+        returns build_rc. on_build_step fires when the build command runs."""
+        def stream(cmd, cwd=None):
+            is_build = "--build" in cmd
+            if is_build:
+                if on_build_step:
+                    on_build_step()
+                return build_rc
+            return 0
+        self.bm._stream = stream
+
+    def test_fresh_binary_after_failed_step_is_warnings_not_failure(self):
+        bin_path = os.path.join(self.build, "bin", "llama-server")
+        # binary appears DURING the build step -> mtime is after `started`
+        self._stub(build_rc=1, on_build_step=lambda: _touch(bin_path))
+        self.bm.run_build(self.src, self.build, {}, pull=False)
+        self.assertEqual(self.bm.state["phase"], "done_warnings")
+        self.assertEqual(self.bm.state["returncode"], 0)
+        self.assertTrue(self.bm.state.get("warning"))
+        self.assertEqual(self.built, [bin_path])
+
+    def test_stale_binary_after_failed_step_is_a_real_failure(self):
+        # a binary from a PREVIOUS build: mtime well before this build starts
+        bin_path = os.path.join(self.build, "bin", "llama-server")
+        _touch(bin_path, mtime=time.time() - 3600)
+        self._stub(build_rc=1)                     # build fails, touches nothing
+        self.bm.run_build(self.src, self.build, {}, pull=False)
+        self.assertEqual(self.bm.state["phase"], "failed")
+        self.assertEqual(self.built, [], "recorded a stale binary as this build's output")
+
+    def test_no_binary_after_failed_step_is_a_real_failure(self):
+        self._stub(build_rc=1)
+        self.bm.run_build(self.src, self.build, {}, pull=False)
+        self.assertEqual(self.bm.state["phase"], "failed")
+        self.assertEqual(self.built, [])
+
+    def test_clean_build_is_plain_done(self):
+        bin_path = os.path.join(self.build, "bin", "llama-server")
+        self._stub(build_rc=0, on_build_step=lambda: _touch(bin_path))
+        self.bm.run_build(self.src, self.build, {}, pull=False)
+        self.assertEqual(self.bm.state["phase"], "done")
+        self.assertIsNone(self.bm.state.get("warning"))
+        self.assertEqual(self.built, [bin_path])
+
+    def test_configure_failure_is_failure_even_with_a_binary(self):
+        _touch(os.path.join(self.build, "bin", "llama-server"))
+        # fail the configure step (the first non-git _stream), not the build step
+        def stream(cmd, cwd=None):
+            if cmd[:1] == ["cmake"] and "--build" not in cmd:
+                return 1                            # configure fails
+            return 0
+        self.bm._stream = stream
+        self.bm.run_build(self.src, self.build, {}, pull=False)
+        self.assertEqual(self.bm.state["phase"], "failed")
+        self.assertEqual(self.built, [])
+
+    def test_warning_is_cleared_on_the_next_run(self):
+        bin_path = os.path.join(self.build, "bin", "llama-server")
+        self._stub(build_rc=1, on_build_step=lambda: _touch(bin_path))
+        self.bm.run_build(self.src, self.build, {}, pull=False)
+        self.assertTrue(self.bm.state.get("warning"))
+        # a clean re-run must not leave the old warning hanging around
+        self._stub(build_rc=0, on_build_step=lambda: _touch(bin_path))
+        self.bm.run_build(self.src, self.build, {}, pull=False)
+        self.assertEqual(self.bm.state["phase"], "done")
+        self.assertIsNone(self.bm.state.get("warning"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_build_server_bin.py
+++ b/tests/test_build_server_bin.py
@@ -1,0 +1,137 @@
+"""Record where a finished build actually put llama-server (issue #6).
+
+bootstrap guesses `<src>/build/bin/llama-server`, which is right for Ninja/Make
+but wrong for MSVC's multi-config generator (`bin/Release/llama-server.exe`).
+The reporter had to hand-edit config.json after every build. The build already
+knows where the binary landed, so it should say so.
+"""
+import conftest_paths  # noqa: F401
+import json, os, tempfile, unittest
+
+import config, routes
+from builder import BuildManager
+
+
+def _touch(path):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write("")
+    return path
+
+
+class LocateServerBinTest(unittest.TestCase):
+    """Pure lookup over the build tree - no config, no side effects."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def test_none_without_a_build_dir(self):
+        self.assertIsNone(BuildManager.locate_server_bin(""))
+
+    def test_none_when_nothing_was_built(self):
+        self.assertIsNone(BuildManager.locate_server_bin(self.tmp))
+
+    def test_finds_msvc_release_exe(self):
+        want = _touch(os.path.join(self.tmp, "bin", "Release", "llama-server.exe"))
+        self.assertEqual(BuildManager.locate_server_bin(self.tmp), want)
+
+    def test_finds_flat_bin_binary(self):
+        want = _touch(os.path.join(self.tmp, "bin", "llama-server"))
+        self.assertEqual(BuildManager.locate_server_bin(self.tmp), want)
+
+    def test_prefers_release_over_flat_bin(self):
+        _touch(os.path.join(self.tmp, "bin", "llama-server"))
+        want = _touch(os.path.join(self.tmp, "bin", "Release", "llama-server.exe"))
+        self.assertEqual(BuildManager.locate_server_bin(self.tmp), want)
+
+    def test_ignores_a_bin_dir_without_the_server(self):
+        _touch(os.path.join(self.tmp, "bin", "llama-cli"))
+        self.assertIsNone(BuildManager.locate_server_bin(self.tmp))
+
+
+class BuildRecordsBinaryTest(unittest.TestCase):
+    """A successful build reports the binary; a failed one must not."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.src = os.path.join(self.tmp, "src")
+        self.build = os.path.join(self.tmp, "build")
+        os.makedirs(self.src)
+        self.seen = []
+        self.bm = BuildManager(os.path.join(self.tmp, "logs"),
+                               on_built=self.seen.append)
+        self.bm._stream = lambda cmd, cwd=None: 0      # never invoke cmake
+
+    def test_success_reports_the_located_binary(self):
+        want = _touch(os.path.join(self.build, "bin", "llama-server"))
+        self.bm.run_build(self.src, self.build, {}, pull=False)
+        self.assertEqual(self.bm.state["phase"], "done")
+        self.assertEqual(self.seen, [want])
+        self.assertEqual(self.bm.state.get("server_bin"), want)
+
+    def test_success_without_a_binary_reports_nothing(self):
+        self.bm.run_build(self.src, self.build, {}, pull=False)
+        self.assertEqual(self.bm.state["phase"], "done")
+        self.assertEqual(self.seen, [])
+
+    def test_failed_build_reports_nothing(self):
+        _touch(os.path.join(self.build, "bin", "llama-server"))
+        self.bm._stream = lambda cmd, cwd=None: 1      # cmake configure fails
+        self.bm.run_build(self.src, self.build, {}, pull=False)
+        self.assertEqual(self.bm.state["phase"], "failed")
+        self.assertEqual(self.seen, [])
+
+    def test_a_raising_callback_never_fails_the_build(self):
+        _touch(os.path.join(self.build, "bin", "llama-server"))
+        def boom(_):
+            raise OSError("config.json is read-only")
+        bm = BuildManager(os.path.join(self.tmp, "logs2"), on_built=boom)
+        bm._stream = lambda cmd, cwd=None: 0
+        bm.run_build(self.src, self.build, {}, pull=False)
+        self.assertEqual(bm.state["phase"], "done")
+        self.assertIn("read-only", bm.tail())
+
+
+class RecordServerBinPolicyTest(unittest.TestCase):
+    """Fill in a missing or stale path, but never overrule a working one the
+    user chose deliberately (they may have moved the binary themselves)."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self._saved = config.CONFIG
+        config.CONFIG = os.path.join(self.tmp, "config.json")
+        self.built = _touch(os.path.join(self.tmp, "build", "bin", "llama-server"))
+
+    def tearDown(self):
+        config.CONFIG = self._saved
+
+    def _write_cfg(self, **keys):
+        with open(config.CONFIG, "w", encoding="utf-8") as f:
+            json.dump(keys, f)
+
+    def test_sets_an_unconfigured_path(self):
+        self._write_cfg(server_bin="")
+        self.assertTrue(routes._record_server_bin("server_bin", self.built))
+        self.assertEqual(config.load()["server_bin"], self.built)
+
+    def test_replaces_a_path_that_does_not_exist(self):
+        self._write_cfg(server_bin=os.path.join(self.tmp, "guessed", "llama-server"))
+        self.assertTrue(routes._record_server_bin("server_bin", self.built))
+        self.assertEqual(config.load()["server_bin"], self.built)
+
+    def test_leaves_an_existing_working_path_alone(self):
+        chosen = _touch(os.path.join(self.tmp, "chosen", "llama-server"))
+        self._write_cfg(server_bin=chosen)
+        self.assertFalse(routes._record_server_bin("server_bin", self.built))
+        self.assertEqual(config.load()["server_bin"], chosen)
+
+    def test_writes_the_ik_llama_key_for_that_engine(self):
+        self._write_cfg(ik_llama_server_bin="")
+        self.assertTrue(routes._record_server_bin("ik_llama_server_bin", self.built))
+        c = config.load()
+        self.assertEqual(c["ik_llama_server_bin"], self.built)
+        self.assertEqual(c["server_bin"], "", "wrote the wrong engine's key")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_first_run.py
+++ b/tests/test_first_run.py
@@ -1,0 +1,202 @@
+"""First-run blockers reported in issue #5.
+
+A fresh Windows install hit a chain of failures that all shared one shape: a
+path or a port was wrong, and the code found out by handing the bad value to an
+external process (cmake, llama-server) whose error the user never saw. These
+tests pin the checks that happen *before* we shell out.
+"""
+import conftest_paths  # noqa: F401
+import json, os, tempfile, unittest
+
+import builder, config, osplat, router_ctl
+from builder import BuildManager
+
+
+class _ConfigTempCase(unittest.TestCase):
+    """config-touching tests must never read or write the real config.json."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self._saved = config.CONFIG
+        config.CONFIG = os.path.join(self.tmp, "config.json")
+
+    def tearDown(self):
+        config.CONFIG = self._saved
+
+    def _write_cfg(self, **keys):
+        with open(config.CONFIG, "w", encoding="utf-8") as f:
+            json.dump(keys, f)
+
+
+class IniPathIsAbsoluteTest(_ConfigTempCase):
+    """The router is launched detached and does not inherit the panel's CWD, so
+    a relative models_ini (config.example.json ships './models.ini') resolved
+    against whatever directory the user happened to launch from - it read a
+    different, usually empty, registry and loaded 0 models."""
+
+    def test_relative_models_ini_resolves_against_repo_root(self):
+        self._write_cfg(models_ini="./models.ini")
+        p = config.ini_path()
+        self.assertTrue(os.path.isabs(p), f"expected absolute, got {p!r}")
+        self.assertEqual(p, os.path.join(config.ROOT, "models.ini"))
+
+    def test_nested_relative_path_resolves(self):
+        self._write_cfg(models_ini="reg/models.ini")
+        self.assertEqual(config.ini_path(),
+                         os.path.join(config.ROOT, "reg", "models.ini"))
+
+    def test_absolute_models_ini_is_left_alone(self):
+        absolute = os.path.join(self.tmp, "elsewhere.ini")
+        self._write_cfg(models_ini=absolute)
+        self.assertEqual(config.ini_path(), absolute)
+
+    def test_ikllama_sibling_is_also_absolute(self):
+        self._write_cfg(models_ini="./models.ini", active_engine="ikllama")
+        p = config.ini_path()
+        self.assertTrue(os.path.isabs(p), f"expected absolute, got {p!r}")
+        self.assertEqual(p, os.path.join(config.ROOT, "models-ikllama.ini"))
+
+    def test_explicit_ikllama_relative_path_resolves(self):
+        self._write_cfg(models_ini="./models.ini", active_engine="ikllama",
+                        ik_llama_models_ini="./ik.ini")
+        self.assertEqual(config.ini_path(), os.path.join(config.ROOT, "ik.ini"))
+
+
+class EnsureModelsIniTest(_ConfigTempCase):
+    """The router refuses to start when models.ini is absent, and nothing ever
+    created it: ensure_global() existed but had no callers at all."""
+
+    def test_creates_the_file_when_missing(self):
+        path = os.path.join(self.tmp, "models.ini")
+        created = config.ensure_models_ini(path)
+        self.assertTrue(created)
+        self.assertTrue(os.path.exists(path))
+
+    def test_created_file_has_a_global_section(self):
+        path = os.path.join(self.tmp, "models.ini")
+        config.ensure_models_ini(path)
+        self.assertIn("*", config.read_sections(path))
+
+    def test_existing_file_is_never_touched(self):
+        path = os.path.join(self.tmp, "models.ini")
+        original = "[*]\nctx-size = 4096\n\n[mymodel]\nmodel = /m.gguf\n"
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(original)
+        self.assertFalse(config.ensure_models_ini(path))
+        with open(path, encoding="utf-8") as f:
+            self.assertEqual(f.read(), original)
+
+    def test_creates_missing_parent_directory(self):
+        path = os.path.join(self.tmp, "nested", "dir", "models.ini")
+        self.assertTrue(config.ensure_models_ini(path))
+        self.assertTrue(os.path.exists(path))
+
+
+class RouterPortConflictTest(unittest.TestCase):
+    """Port 8080 is a popular default (XAMPP, Apache). llama-server logged
+    'couldn't bind HTTP server socket' and died, but start() had already
+    returned success, so the dashboard just showed every model offline."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.fake_bin = os.path.join(self.tmp, "llama-server")
+        with open(self.fake_bin, "w") as f:      # must exist to reach the port check
+            f.write("")
+        self._saved = router_ctl.is_running
+        self.spawned = []
+        self._saved_popen = router_ctl.subprocess.Popen
+        router_ctl.subprocess.Popen = lambda *a, **k: self.spawned.append(a)
+
+    def tearDown(self):
+        router_ctl.is_running = self._saved
+        router_ctl.subprocess.Popen = self._saved_popen
+
+    def test_refuses_to_start_when_port_is_taken(self):
+        router_ctl.is_running = lambda port: True
+        ok, err = router_ctl.start(self.fake_bin, "m.ini", 8080, "127.0.0.1", "", self.tmp)
+        self.assertFalse(ok)
+        self.assertIn("8080", err)
+        self.assertIn("in use", err.lower())
+
+    def test_does_not_spawn_a_doomed_process(self):
+        router_ctl.is_running = lambda port: True
+        router_ctl.start(self.fake_bin, "m.ini", 8080, "127.0.0.1", "", self.tmp)
+        self.assertEqual(self.spawned, [], "spawned llama-server onto a taken port")
+
+    def test_starts_normally_when_the_port_is_free(self):
+        router_ctl.is_running = lambda port: False
+        ok, err = router_ctl.start(self.fake_bin, "m.ini", 8080, "127.0.0.1", "", self.tmp)
+        self.assertTrue(ok, err)
+        self.assertEqual(len(self.spawned), 1)
+
+    def test_missing_binary_still_reported_first(self):
+        router_ctl.is_running = lambda port: True
+        ok, err = router_ctl.start("", "m.ini", 8080, "127.0.0.1", "", self.tmp)
+        self.assertFalse(ok)
+        self.assertIn("server_bin", err)
+
+
+class BuildPathValidationTest(unittest.TestCase):
+    """With server_bin blank (the intended first-run state) Rebuild ran
+    `cmake -B  -S ` and surfaced CMake's own 'No build directory specified'."""
+
+    def test_empty_source_is_rejected(self):
+        err = BuildManager.validate_paths("", "/b", isdir=lambda p: True)
+        self.assertTrue(err)
+        self.assertIn("source", err.lower())
+
+    def test_empty_build_dir_is_rejected(self):
+        err = BuildManager.validate_paths("/s", "", isdir=lambda p: True)
+        self.assertTrue(err)
+        self.assertIn("build", err.lower())
+
+    def test_nonexistent_source_is_rejected(self):
+        err = BuildManager.validate_paths("/nope", "/b", isdir=lambda p: False)
+        self.assertTrue(err)
+        self.assertIn("/nope", err)
+
+    def test_valid_paths_pass(self):
+        self.assertEqual(BuildManager.validate_paths("/s", "/b", isdir=lambda p: True), "")
+
+    def test_build_dir_need_not_exist_yet(self):
+        """cmake creates -B itself; only the source tree must already be there."""
+        self.assertEqual(
+            BuildManager.validate_paths("/s", "/b", isdir=lambda p: p == "/s"), "")
+
+    def test_run_build_fails_fast_without_invoking_cmake(self):
+        bm = BuildManager(tempfile.mkdtemp())
+        calls = []
+        bm._stream = lambda cmd, cwd=None: calls.append(cmd) or 0
+        bm.run_build("", "", {}, pull=False)
+        self.assertEqual(calls, [], "invoked cmake despite unset paths")
+        self.assertEqual(bm.state["phase"], "failed")
+        self.assertIn("source", bm.tail().lower())
+
+
+class PathRefreshTest(unittest.TestCase):
+    """winget/choco edit the machine PATH, but shutil.which() reads the copy
+    this process inherited at launch - so a freshly installed ninja stayed
+    MISSING until LlamaForge was restarted."""
+
+    def test_refresh_path_is_safe_to_call(self):
+        before = os.environ.get("PATH", "")
+        try:
+            osplat.refresh_path()
+        finally:
+            if not os.environ.get("PATH"):
+                os.environ["PATH"] = before
+        self.assertTrue(os.environ.get("PATH"), "refresh_path() emptied PATH")
+
+    def test_refresh_path_reports_whether_it_did_anything(self):
+        self.assertIsInstance(osplat.refresh_path(), bool)
+
+    @unittest.skipUnless(osplat.IS_WIN, "registry PATH is Windows-only")
+    def test_windows_refresh_keeps_existing_entries(self):
+        os.environ["PATH"] = os.environ.get("PATH", "") + os.pathsep + "C:\\lf-sentinel"
+        osplat.refresh_path()
+        self.assertIn("C:\\lf-sentinel", os.environ["PATH"],
+                      "refresh_path() dropped process-local PATH entries")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fit_label.py
+++ b/tests/test_fit_label.py
@@ -1,0 +1,47 @@
+"""Offload-aware fit label (issue #4 part 1).
+
+hub._fit() rates on size alone and mislabels the MoE / partial-offload case the
+reporter hit ("twice my VRAM, fits great"). fit_label() derives the rating from
+the physics prediction that post_hub_files already computes, so the label and
+the tok/s badge stop contradicting each other.
+"""
+import conftest_paths  # noqa: F401
+import unittest
+
+import vram_predict
+
+
+def _pred(regime, usability, confidence="high"):
+    return {"regime": regime, "usability": usability, "confidence": confidence,
+            "tok_s": 42.0, "gpu_resident_frac": 0.5}
+
+
+class FitLabelTest(unittest.TestCase):
+    def test_gpu_resident_and_usable_fits(self):
+        self.assertEqual(vram_predict.fit_label(_pred("gpu-resident", "interactive")), "fits")
+
+    def test_hybrid_but_fast_is_tight_not_offload(self):
+        # The reported MoE case: model larger than VRAM, experts offloaded, still
+        # interactive. Must not read as "offload".
+        self.assertEqual(vram_predict.fit_label(_pred("hybrid", "interactive")), "tight")
+        self.assertEqual(vram_predict.fit_label(_pred("hybrid", "usable")), "tight")
+
+    def test_streaming_is_offload(self):
+        self.assertEqual(vram_predict.fit_label(_pred("streaming", "slow")), "offload")
+
+    def test_slow_usability_is_offload_regardless_of_regime(self):
+        self.assertEqual(vram_predict.fit_label(_pred("hybrid", "slow")), "offload")
+        self.assertEqual(vram_predict.fit_label(_pred("gpu-resident", "impractical")), "offload")
+
+    def test_unknown_confidence_defers(self):
+        self.assertEqual(vram_predict.fit_label(_pred("gpu-resident", "interactive", "unknown")),
+                         "unknown")
+
+    def test_missing_fields_defer(self):
+        self.assertEqual(vram_predict.fit_label({}), "unknown")
+        self.assertEqual(vram_predict.fit_label(None), "unknown")
+        self.assertEqual(vram_predict.fit_label({"confidence": "high"}), "unknown")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mtp_autowire.py
+++ b/tests/test_mtp_autowire.py
@@ -1,0 +1,134 @@
+"""Auto-wire MTP draft models (issue #3).
+
+scanner attaches an mtp-* sibling as a speculative draft model, enabling
+spec-type=draft-mtp only when the sidecar declares NextN layers (the signal
+llama.cpp gates on). Wiring is additive: spec-type is also the ngram-* selector,
+so a re-scan must never wipe a hand-set speculative mode.
+"""
+import conftest_paths  # noqa: F401
+import json, os, tempfile, unittest
+from unittest import mock
+
+import config, gguf, routes, scanner
+
+
+class HasNextnTest(unittest.TestCase):
+    def _write_gguf(self, kvs):
+        """Minimal GGUF with the given (key, int_value) pairs. type 4 = uint32."""
+        import struct
+        path = os.path.join(self.tmp, "m.gguf")
+        with open(path, "wb") as f:
+            f.write(b"GGUF")
+            f.write(struct.pack("<I", 3))          # version
+            f.write(struct.pack("<Q", 0))          # tensor count
+            f.write(struct.pack("<Q", len(kvs)))   # kv count
+            for k, v in kvs:
+                kb = k.encode()
+                f.write(struct.pack("<Q", len(kb))); f.write(kb)
+                f.write(struct.pack("<I", 4))      # value type uint32
+                f.write(struct.pack("<I", v))
+        return path
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def test_true_when_nextn_layers_present(self):
+        p = self._write_gguf([("gemma4-assistant.nextn_predict_layers", 2)])
+        self.assertTrue(gguf.has_nextn(p))
+
+    def test_false_when_zero_layers(self):
+        p = self._write_gguf([("arch.nextn_predict_layers", 0)])
+        self.assertFalse(gguf.has_nextn(p))
+
+    def test_false_when_absent(self):
+        p = self._write_gguf([("arch.block_count", 40)])
+        self.assertFalse(gguf.has_nextn(p))
+
+    def test_false_on_unreadable(self):
+        self.assertFalse(gguf.has_nextn(os.path.join(self.tmp, "nope.gguf")))
+
+
+class BuildEntriesMtpTest(unittest.TestCase):
+    """Pure over fake paths; has_nextn is patched so no files are read."""
+
+    def _entries(self, paths, nextn=False):
+        with mock.patch.object(scanner, "_slug", side_effect=lambda s: s.lower()), \
+             mock.patch("gguf.has_nextn", return_value=nextn), \
+             mock.patch("gguf.metadata", return_value={}):
+            return {e["id"]: e for e in scanner.build_entries(paths)}
+
+    def test_sidecar_attaches_as_draft_model(self):
+        paths = ["/m/model.gguf", "/m/mtp-model.gguf"]
+        e = self._entries(paths, nextn=True)
+        self.assertEqual(len(e), 1)                 # sidecar isn't a standalone model
+        (entry,) = e.values()
+        self.assertEqual(entry["draft_model"], "/m/mtp-model.gguf")
+        self.assertTrue(entry.get("draft_mtp"))
+
+    def test_attach_only_when_no_nextn(self):
+        paths = ["/m/model.gguf", "/m/mtp-model.gguf"]
+        (entry,) = self._entries(paths, nextn=False).values()
+        self.assertEqual(entry["draft_model"], "/m/mtp-model.gguf")
+        self.assertNotIn("draft_mtp", entry)        # inert until the user opts in
+
+    def test_no_sidecar_no_draft_keys(self):
+        (entry,) = self._entries(["/m/model.gguf"]).values()
+        self.assertNotIn("draft_model", entry)
+        self.assertNotIn("draft_mtp", entry)
+
+    def test_sidecar_in_other_dir_not_attached(self):
+        paths = ["/a/model.gguf", "/b/mtp-model.gguf"]
+        (entry,) = self._entries(paths, nextn=True).values()
+        self.assertNotIn("draft_model", entry)
+
+
+class ScanApplyMtpTest(unittest.TestCase):
+    """Route-level: additive wiring that never clobbers a hand-set spec-type."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self._saved = config.CONFIG
+        config.CONFIG = os.path.join(self.tmp, "config.json")
+        self.ini = os.path.join(self.tmp, "models.ini")
+        with open(config.CONFIG, "w") as f:
+            json.dump({"models_ini": self.ini}, f)
+        # keep the router + ctx pass out of the way
+        self._r, self._c = routes.router, config.apply_ctx_defaults
+        routes.router = lambda *a, **k: (200, {})
+        config.apply_ctx_defaults = lambda *a, **k: {"changed": []}
+
+    def tearDown(self):
+        config.CONFIG = self._saved
+        routes.router, config.apply_ctx_defaults = self._r, self._c
+
+    def _apply(self, entries):
+        req = mock.Mock()
+        req.body = {"entries": entries}
+        routes.post_scan_apply(req)
+
+    def test_enables_draft_mtp_on_a_fresh_model(self):
+        self._apply([{"id": "qwopus", "model": "/m/q.gguf",
+                      "draft_model": "/m/mtp-q.gguf", "draft_mtp": True}])
+        sect = config.read_sections()["qwopus"]
+        self.assertEqual(sect["spec-draft-model"], "/m/mtp-q.gguf")
+        self.assertEqual(sect["spec-type"], "draft-mtp")
+
+    def test_does_not_overwrite_a_hand_set_spec_type(self):
+        config.set_keys("ornith", {"model": "/m/o.gguf", "spec-type": "ngram-mod"})
+        self._apply([{"id": "ornith", "model": "/m/o.gguf",
+                      "draft_model": "/m/mtp-o.gguf", "draft_mtp": True}])
+        sect = config.read_sections()["ornith"]
+        self.assertEqual(sect["spec-type"], "ngram-mod", "clobbered a hand-set mode")
+        # the draft model still attaches (it was absent), harmless while inert
+        self.assertEqual(sect["spec-draft-model"], "/m/mtp-o.gguf")
+
+    def test_attach_only_leaves_spec_type_unset(self):
+        self._apply([{"id": "m", "model": "/m/m.gguf",
+                      "draft_model": "/m/mtp-m.gguf"}])   # no draft_mtp
+        sect = config.read_sections()["m"]
+        self.assertEqual(sect["spec-draft-model"], "/m/mtp-m.gguf")
+        self.assertNotIn("spec-type", sect)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_preset_binding.py
+++ b/tests/test_preset_binding.py
@@ -1,0 +1,118 @@
+"""Bind a preset as a model's default (issue #2).
+
+A binding lives in config.json (preset_bindings: {model_id: preset_name}); the
+preset's knobs are materialized into the model's models.ini section when bound
+and re-materialized when the preset is edited. Hand edits win by write-order.
+"""
+import conftest_paths  # noqa: F401
+import json, os, tempfile, unittest
+from unittest import mock
+
+import config, routes
+
+
+class _ConfigTempCase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self._saved = config.CONFIG
+        config.CONFIG = os.path.join(self.tmp, "config.json")
+
+    def tearDown(self):
+        config.CONFIG = self._saved
+
+
+class BindingStorageTest(_ConfigTempCase):
+    def setUp(self):
+        super().setUp()
+        config.save_preset("coding", {"temp": "0.2"})
+
+    def test_bind_records_the_pair(self):
+        config.bind_preset("qwopus", "coding")
+        self.assertEqual(config.get_bindings(), {"qwopus": "coding"})
+
+    def test_bind_unknown_preset_raises(self):
+        with self.assertRaises(ValueError):
+            config.bind_preset("qwopus", "no-such-preset")
+
+    def test_unbind_removes_only_that_model(self):
+        config.bind_preset("qwopus", "coding")
+        config.bind_preset("ornith", "coding")
+        self.assertTrue(config.unbind_preset("qwopus"))
+        self.assertEqual(config.get_bindings(), {"ornith": "coding"})
+
+    def test_unbind_absent_is_false(self):
+        self.assertFalse(config.unbind_preset("ghost"))
+
+    def test_bindings_for_preset(self):
+        config.bind_preset("qwopus", "coding")
+        config.bind_preset("ornith", "coding")
+        config.save_preset("chat", {"temp": "0.8"})
+        config.bind_preset("gemma", "chat")
+        self.assertEqual(sorted(config.bindings_for_preset("coding")), ["ornith", "qwopus"])
+
+    def test_deleting_a_preset_drops_its_bindings(self):
+        config.bind_preset("qwopus", "coding")
+        config.delete_preset("coding")
+        self.assertEqual(config.get_bindings(), {})
+
+    def test_prune_binding_on_model_delete(self):
+        config.bind_preset("qwopus", "coding")
+        self.assertTrue(config.prune_binding("qwopus"))
+        self.assertEqual(config.get_bindings(), {})
+
+
+class BindMaterializeRouteTest(_ConfigTempCase):
+    """Route-level: binding writes the preset's knobs; editing the preset
+    re-materializes into every bound model."""
+
+    def setUp(self):
+        super().setUp()
+        self.ini = os.path.join(self.tmp, "models.ini")
+        cfg = config.load(); cfg["models_ini"] = self.ini; config.save(cfg)
+        config.set_keys("qwopus", {"model": "/m/q.gguf"})
+        config.save_preset("coding", {"temp": "0.2", "top-k": "20"})
+        self.applied = []
+        # capture materialization instead of touching a live router
+        self._orig = routes._apply_knobs_and_reload
+        routes._apply_knobs_and_reload = lambda mid, clean: self.applied.append((mid, clean)) or False
+
+    def tearDown(self):
+        routes._apply_knobs_and_reload = self._orig
+        super().tearDown()
+
+    def _post(self, fn, **body):
+        req = mock.Mock(); req.body = body
+        return fn(req)
+
+    def test_bind_materializes_the_preset(self):
+        self._post(routes.post_presets_bind, model="qwopus", name="coding")
+        self.assertEqual(config.get_bindings(), {"qwopus": "coding"})
+        self.assertEqual(len(self.applied), 1)
+        mid, clean = self.applied[0]
+        self.assertEqual(mid, "qwopus")
+        self.assertEqual(clean.get("temp"), "0.2")
+
+    def test_editing_a_bound_preset_resyncs_every_model(self):
+        self._post(routes.post_presets_bind, model="qwopus", name="coding")
+        config.set_keys("ornith", {"model": "/m/o.gguf"})
+        self._post(routes.post_presets_bind, model="ornith", name="coding")
+        self.applied.clear()
+        self._post(routes.post_presets_save, name="coding", settings={"temp": "0.9"})
+        synced = {mid for mid, _ in self.applied}
+        self.assertEqual(synced, {"qwopus", "ornith"})
+        self.assertTrue(all(clean.get("temp") == "0.9" for _, clean in self.applied))
+
+    def test_unbind_leaves_knobs_in_place(self):
+        self._post(routes.post_presets_bind, model="qwopus", name="coding")
+        self.applied.clear()
+        self._post(routes.post_presets_bind, model="qwopus", name="")   # unbind
+        self.assertEqual(config.get_bindings(), {})
+        self.assertEqual(self.applied, [], "unbind must not rewrite the section")
+
+    def test_saving_an_unbound_preset_materializes_nothing(self):
+        self._post(routes.post_presets_save, name="coding", settings={"temp": "0.5"})
+        self.assertEqual(self.applied, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/index.html
+++ b/web/index.html
@@ -206,7 +206,7 @@ button.primary{background:var(--amber);color:var(--on-amber);border-color:var(--
 button.primary:hover{box-shadow:0 0 14px var(--amber-dim)}
 button.ghost:hover{border-color:var(--cyan);color:var(--cyan-text)}
 button:disabled{opacity:.4;cursor:not-allowed}
-.msg{font-size:11px;margin-left:auto}.msg.ok{color:var(--green)}.msg.err{color:var(--red)}.msg.work{color:var(--amber-status)}
+.msg{font-size:11px;margin-left:auto}.msg.ok{color:var(--green)}.msg.err{color:var(--red)}.msg.work{color:var(--amber-status)}.msg.warn{color:var(--amber-text)}
 .card{background:var(--panel);border:1px solid var(--hair);padding:16px 18px;margin-bottom:14px}
 .card h3{font-family:var(--disp);letter-spacing:.14em;text-transform:uppercase;font-size:12px;color:var(--amber-text);margin:0 0 12px}
 .kv{display:flex;justify-content:space-between;padding:6px 0;border-bottom:1px solid var(--hair-dim);font-size:12px;gap:12px}

--- a/web/index.html
+++ b/web/index.html
@@ -245,6 +245,8 @@ button:disabled{opacity:.4;cursor:not-allowed}
 .presetbar .pchip{font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:var(--amber-text);border:1px solid var(--amber-dim);padding:5px 10px;cursor:pointer;display:inline-flex;gap:7px;align-items:center}
 .presetbar .pchip:hover{background:var(--amber);color:var(--on-amber)}
 .presetbar .pchip .px{color:var(--dim);font-size:12px}.presetbar .pchip:hover .px{color:var(--on-amber)}
+.presetbar .pchip .pbind{font-size:11px;color:var(--dim)}.presetbar .pchip:hover .pbind{color:var(--on-amber)}
+.presetbar .pchip.bound{border-color:var(--amber-text);background:var(--amber-tint)}.presetbar .pchip.bound .pbind{color:var(--amber-text)}
 .tunebar{display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:8px}
 .tunebar-label{font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--dim);cursor:help}
 .tunebar-results{margin-top:6px;font-size:11px;font-family:var(--mono);border:1px solid var(--border-dim);border-radius:4px;padding:6px 8px}

--- a/web/js/build.js
+++ b/web/js/build.js
@@ -148,6 +148,11 @@ async function pollBuild() {
       msg.className = "msg ok";
       msg.textContent = "build OK" + (s.started&&s.finished?` in ${fmtDur(s.finished-s.started)}`:"");
       clearInterval(buildPoll);
+    } else if (msg && s.phase === "done_warnings") {
+      // llama-server built, but a non-essential later target (UI assets) failed.
+      msg.className = "msg warn";
+      msg.textContent = "built with warnings - " + (s.warning || "see log");
+      clearInterval(buildPoll);
     } else if (msg && s.phase === "failed") {
       msg.className = "msg err"; msg.textContent = "build failed - see log";
       clearInterval(buildPoll);

--- a/web/js/models.js
+++ b/web/js/models.js
@@ -408,7 +408,13 @@ function openClientConfig(id) {
 /* ---------- presets ---------- */
 function presetBar(m) {
   const P = cfgOf().presets || {};
-  const chips = Object.keys(P).map(n => `<span class="pchip" data-preset-apply="${esc(n)}" data-preset-model="${esc(m.id)}" title="apply preset to this model">${esc(n)}<span class="px" data-preset-del="${esc(n)}" title="delete preset">&times;</span></span>`).join("");
+  const bound = (cfgOf().preset_bindings || {})[m.id] || "";
+  const chips = Object.keys(P).map(n => {
+    const isBound = n === bound;
+    return `<span class="pchip${isBound ? " bound" : ""}" data-preset-apply="${esc(n)}" data-preset-model="${esc(m.id)}" title="apply preset to this model">`
+      + `<span class="pbind" data-preset-bind="${esc(n)}" data-preset-bind-model="${esc(m.id)}" title="${isBound ? "bound as default - click to unbind" : "bind as this model's default"}">${isBound ? "◉" : "○"}</span>`
+      + `${esc(n)}<span class="px" data-preset-del="${esc(n)}" title="delete preset">&times;</span></span>`;
+  }).join("");
   return `<div class="presetbar">
     <span style="font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--dim)">Presets</span>
     ${chips||'<span class="note" style="margin:0">none saved yet</span>'}
@@ -419,6 +425,16 @@ async function applyPreset(model, name) {
   const r = await api("/api/presets/apply", {model, name});
   if (r.ok) { toast(`Applied "${name}"`, "ok"); delete diagCache[model]; invalidateKnobs(); await refresh(true); }
   else toast(r.error || "apply failed", "err");
+}
+async function bindPreset(model, name) {
+  // toggle: clicking the dot of an already-bound preset unbinds it
+  const cur = (cfgOf().preset_bindings || {})[model] || "";
+  const next = (cur === name) ? "" : name;
+  const r = await api("/api/presets/bind", {model, name: next});
+  if (r.ok) {
+    toast(next ? `Bound "${name}" as default` : `Unbound "${name}"`, "ok");
+    delete diagCache[model]; invalidateKnobs(); await refresh(true);
+  } else toast(r.error || "bind failed", "err");
 }
 async function savePresetFrom(model) {
   const row = $(`.row[data-id="${CSS.escape(model)}"]`); if (!row) return;
@@ -661,6 +677,8 @@ export function initModels() {
     const pApply = e.target.closest("[data-preset-apply]");
     if (pApply) {
       e.stopPropagation();
+      const pbind = e.target.closest("[data-preset-bind]");
+      if (pbind) { await bindPreset(pbind.dataset.presetBindModel, pbind.dataset.presetBind); return; }
       const pdel = e.target.closest("[data-preset-del]");
       if (pdel) { await api("/api/presets/delete", {name: pdel.dataset.presetDel}); toast("Preset deleted","ok"); await refresh(true); return; }
       await applyPreset(pApply.dataset.presetModel, pApply.dataset.presetApply); return;


### PR DESCRIPTION
Closes #5. Addresses #2, #3, #6. Partially addresses #4.

Five commits, each self-contained, on top of the merged engine work. 48 new
tests (443 total green).

## First-run blockers (#5, #6) — `0d244a4`
A fresh Windows install hit a chain of failures that shared one shape: a bad
value (empty path, relative path, taken port) was handed to an external process
whose error the user never saw in context.

- **config.json missing** → both launchers seed it from `config.example.json`
  instead of dying on a raw traceback.
- **models.ini never created** → `config.ensure_models_ini()`, wired into
  startup and both launchers (they start the router before the backend, so they
  can't wait for it). Replaces the never-called `ensure_global()`.
- **Relative `models_ini`** → the detached router resolved `./models.ini`
  against its own CWD and loaded 0 models. `config._abs()` anchors to repo root;
  mirrored in `run.ps1` / `run.sh`.
- **Build with unset paths** ran `cmake -B  -S ` → `BuildManager.validate_paths()`
  answers first.
- **Port 8080 conflict** was reported as success → `router_ctl.start()` refuses
  a bound port; launchers name the offending process.
- **Freshly-installed tools stayed MISSING** until restart → `osplat.refresh_path()`
  re-reads PATH from the registry (stdlib `winreg`, no-op on POSIX).
- **#6: `server_bin` guessed wrong under MSVC** → `BuildManager.locate_server_bin()`
  records what the build actually produced, correcting bootstrap's `bin/llama-server`
  guess. Also fixes a 2-handle-per-restart leak in `router_ctl.start()`.

## #2 — Bind a preset as a model's default — `e53908e`
The issue's proposed `preset =` key in `models.ini` would crash the load (every
section key becomes a llama-server flag; there's no `--preset`). Bindings live in
`config.json` and materialize the preset's knobs into the section at bind time;
editing a bound preset re-syncs every model using it. UI: ◉/○ dot per preset chip.

## #3 — Auto-wire MTP draft models — `d46b89a`
Attaches an `mtp-*` sidecar as `spec-draft-model`, enabling `spec-type=draft-mtp`
only when the GGUF declares NextN layers (`gguf.has_nextn()`) — the file-intrinsic
signal llama.cpp itself gates on, so it can't drift from the user's build. Wiring
is **additive**: `spec-type` is also the ngram-* selector, so a re-scan never
wipes a hand-set mode.

## #4 part 1 — Offload-aware fit rating — `ff1586c`
`hub._fit()` rated on size alone and mislabelled the MoE case ("2× my VRAM, fits
great" → CPU OFFLOAD). `vram_predict.fit_label()` derives the label from the
physics prediction already computed alongside it; a fast hybrid placement now
reads "tight", not "offload". The size heuristic stays as the fallback.

**Not in this PR:** #4 part 2 (community/crowdsourced tok-s reports) — it can't
be local-only, so it stays open with its own design.

## #5 item 5 — "Built, with warnings" — `7d97b2a`
When the npm/sharp UI-asset step fails but `llama-server` built, report
`done_warnings` (amber) instead of BUILD FAILED. Freshness is proven by mtime,
not mere presence, so a stale binary from a prior build never masks a real
compile failure.

## Verification
443 tests pass. The MCP browser preview was unavailable during development, so
the #2 bind dots and #5 amber state weren't exercised by a live click — backend
logic, render logic (node harness), asset serving, and config exposure are all
verified.
