### PR TITLE
fix: preserve model overrides in preset bindings

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -9,6 +9,7 @@ import atomicio, gguf
 
 ROOT      = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 CONFIG    = os.path.join(ROOT, "config.json")
+PRESET_ENGINES = ("llamacpp", "ikllama")
 
 # The dashboard is a ThreadingHTTPServer with background workers (stats poller,
 # build/download threads), and config.json is edited by load->mutate->save at
@@ -47,7 +48,8 @@ DEFAULTS = {
     "active_engine": "llamacpp",              # which binary the router uses: llamacpp | ikllama
     "auto_load_model": "",                    # model id to load automatically on launch ("" = none)
     "presets":     {},                       # named knob sets: {name: {knob: value}}
-    "preset_bindings": {},                    # {model_id: preset_name} auto-applied on bind/edit
+    "preset_bindings": {},                    # {engine: {model_id: preset_name}}
+    "preset_binding_snapshots": {},           # {engine: {model_id: {knob: owned_value}}}
     "ui_mode":     "lite",                    # "lite" (curated knobs) or "advanced" (all ~220)
     "onboarded":   False,                     # first-run wizard shown once, then True
     "anthropic_default_model": "",           # fallback local model id for the Anthropic shim
@@ -144,12 +146,25 @@ def migrate():
                 raw = json.load(f)
         except Exception:
             raw = {}
-        if "ui_mode" in raw:
-            return cfg
-        existing = bool(cfg.get("server_bin"))
-        cfg["ui_mode"] = "advanced" if existing else "lite"
-        cfg["onboarded"] = existing
-        save(cfg)
+        changed = False
+        if "ui_mode" not in raw:
+            existing = bool(cfg.get("server_bin"))
+            cfg["ui_mode"] = "advanced" if existing else "lite"
+            cfg["onboarded"] = existing
+            changed = True
+
+        # Issue #2 originally shipped a flat {model_id: preset_name} map.  The
+        # same id can exist in both llama-family registries, so move that legacy
+        # state into whichever engine was active when it was written.
+        binds = raw.get("preset_bindings")
+        if isinstance(binds, dict) and binds and all(isinstance(v, str) for v in binds.values()):
+            engine = cfg.get("active_engine", "llamacpp")
+            if engine not in PRESET_ENGINES:
+                engine = "llamacpp"
+            cfg["preset_bindings"] = {engine: dict(binds)}
+            changed = True
+        if changed:
+            save(cfg)
         return cfg
 
 # ---------------- models.ini (BOM-free, comment-preserving) ----------------
@@ -185,15 +200,16 @@ def _abs(p):
         return p
     return os.path.normpath(os.path.join(ROOT, p))
 
-def ini_path():
-    """The models.ini the active engine reads, always as an absolute path.
+def ini_path(engine=None):
+    """The selected (or active) engine's models.ini, as an absolute path.
 
     ik_llama gets its own registry because the two binaries accept different
     knobs; when the user has not named one, derive a sibling of the llama.cpp
     file. Split on the extension rather than str.replace(".ini", ...), which is
     a global replace and rewrites any directory that happens to contain ".ini"."""
     c = load()
-    if c.get("active_engine") == "ikllama":
+    engine = engine or c.get("active_engine", "llamacpp")
+    if engine == "ikllama":
         p = c.get("ik_llama_models_ini")
         if p:
             return _abs(p)
@@ -359,22 +375,87 @@ def delete_preset(name):
             return False
         del presets[name]
         cfg["presets"] = presets
-        binds = cfg.get("preset_bindings")
-        if isinstance(binds, dict):
-            cfg["preset_bindings"] = {m: n for m, n in binds.items() if n != name}
+        all_binds = _nested_preset_map(cfg, "preset_bindings")
+        snapshots = _nested_preset_map(cfg, "preset_binding_snapshots")
+        for engine, binds in list(all_binds.items()):
+            removed = [model_id for model_id, preset in binds.items() if preset == name]
+            for model_id in removed:
+                del binds[model_id]
+                snapshots.get(engine, {}).pop(model_id, None)
+            if not binds:
+                all_binds.pop(engine, None)
+            if engine in snapshots and not snapshots[engine]:
+                snapshots.pop(engine)
+        cfg["preset_bindings"] = all_binds
+        cfg["preset_binding_snapshots"] = snapshots
         save(cfg)
         return True
 
 # ---------------- preset bindings ----------------
-# A binding names the preset a model defaults to. The knobs themselves are
-# materialized into models.ini by the caller (routes) at bind/edit time - config
-# only owns the mapping, because reloading the router is not config's job.
+# A binding names the preset a model defaults to.  Snapshots contain only the
+# exact values LlamaForge materialized, so route reconciliation can distinguish
+# its defaults from values the user wrote.  Both maps are engine-scoped because
+# llama.cpp and ik_llama have independent models.ini registries.
 
-def get_bindings():
-    b = load().get("preset_bindings")
-    return b if isinstance(b, dict) else {}
+def _preset_engine(cfg, engine=None):
+    engine = (engine or cfg.get("active_engine") or "llamacpp").strip()
+    if engine not in PRESET_ENGINES:
+        raise ValueError(f"presets are not supported for engine: {engine}")
+    return engine
 
-def bind_preset(model_id, name):
+def _scoped_preset_map(cfg, key, engine=None):
+    """Return one engine's state, accepting the pre-engine flat binding map."""
+    engine = _preset_engine(cfg, engine)
+    raw = cfg.get(key)
+    if not isinstance(raw, dict):
+        return {}
+    if key == "preset_bindings" and raw and all(isinstance(v, str) for v in raw.values()):
+        active = _preset_engine(cfg)
+        return dict(raw) if engine == active else {}
+    scoped = raw.get(engine)
+    return dict(scoped) if isinstance(scoped, dict) else {}
+
+def _nested_preset_map(cfg, key):
+    """Normalize mutable preset state to {engine: {...}}."""
+    raw = cfg.get(key)
+    if not isinstance(raw, dict):
+        return {}
+    if key == "preset_bindings" and raw and all(isinstance(v, str) for v in raw.values()):
+        return {_preset_engine(cfg): dict(raw)}
+    return {engine: dict(values) for engine, values in raw.items()
+            if engine in PRESET_ENGINES and isinstance(values, dict)}
+
+def get_bindings(engine=None):
+    cfg = load()
+    return _scoped_preset_map(cfg, "preset_bindings", engine)
+
+def get_binding_snapshots(engine=None):
+    cfg = load()
+    return _scoped_preset_map(cfg, "preset_binding_snapshots", engine)
+
+def get_binding_snapshot(model_id, engine=None):
+    snapshot = get_binding_snapshots(engine).get(model_id)
+    return dict(snapshot) if isinstance(snapshot, dict) else {}
+
+def set_binding_snapshot(model_id, snapshot, engine=None):
+    """Record the knobs currently owned for one model, dropping empty state."""
+    with _LOCK:
+        cfg = load()
+        engine = _preset_engine(cfg, engine)
+        snapshots = _nested_preset_map(cfg, "preset_binding_snapshots")
+        scoped = snapshots.setdefault(engine, {})
+        clean = {str(k): str(v) for k, v in (snapshot or {}).items()}
+        if clean:
+            scoped[model_id] = clean
+        else:
+            scoped.pop(model_id, None)
+        if not scoped:
+            snapshots.pop(engine, None)
+        cfg["preset_binding_snapshots"] = snapshots
+        save(cfg)
+        return dict(scoped)
+
+def bind_preset(model_id, name, engine=None):
     """Bind model_id to preset `name` (or unbind when name is ""). Raises if the
     preset does not exist. Returns the full bindings map."""
     model_id = (model_id or "").strip()
@@ -383,39 +464,56 @@ def bind_preset(model_id, name):
     name = (name or "").strip()
     with _LOCK:
         cfg = load()
-        binds = cfg.get("preset_bindings")
-        if not isinstance(binds, dict):
-            binds = {}
+        engine = _preset_engine(cfg, engine)
+        all_binds = _nested_preset_map(cfg, "preset_bindings")
+        binds = all_binds.setdefault(engine, {})
         if name == "":
             binds.pop(model_id, None)
         else:
             if name not in (cfg.get("presets") or {}):
                 raise ValueError(f"unknown preset: {name}")
             binds[model_id] = name
-        cfg["preset_bindings"] = binds
+        if not binds:
+            all_binds.pop(engine, None)
+        cfg["preset_bindings"] = all_binds
         save(cfg)
-        return binds
+        if name == "":
+            set_binding_snapshot(model_id, {}, engine)
+        return dict(binds)
 
-def unbind_preset(model_id):
+def unbind_preset(model_id, engine=None):
     """Remove a model's binding. Returns True if it had one."""
     with _LOCK:
         cfg = load()
-        binds = cfg.get("preset_bindings")
-        if isinstance(binds, dict) and model_id in binds:
+        engine = _preset_engine(cfg, engine)
+        all_binds = _nested_preset_map(cfg, "preset_bindings")
+        binds = all_binds.get(engine, {})
+        existed = model_id in binds
+        if existed:
             del binds[model_id]
-            cfg["preset_bindings"] = binds
+            if not binds:
+                all_binds.pop(engine, None)
+            cfg["preset_bindings"] = all_binds
+        snapshots = _nested_preset_map(cfg, "preset_binding_snapshots")
+        scoped = snapshots.get(engine, {})
+        had_snapshot = model_id in scoped
+        if had_snapshot:
+            del scoped[model_id]
+            if not scoped:
+                snapshots.pop(engine, None)
+            cfg["preset_binding_snapshots"] = snapshots
+        if existed or had_snapshot:
             save(cfg)
-            return True
-        return False
+        return existed
 
-def prune_binding(model_id):
+def prune_binding(model_id, engine=None):
     """Drop a deleted model's binding. Alias of unbind_preset for call-site
     clarity."""
-    return unbind_preset(model_id)
+    return unbind_preset(model_id, engine)
 
-def bindings_for_preset(name):
+def bindings_for_preset(name, engine=None):
     """Model ids bound to preset `name`."""
-    return [m for m, n in get_bindings().items() if n == name]
+    return [m for m, n in get_bindings(engine).items() if n == name]
 
 # ---------------- automatic ctx-size defaults ----------------
 

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -941,7 +941,7 @@ def post_autotune_refine(req):
 
 
 def post_presets_save(req):
-    name = req.body.get("name", "")
+    name = (req.body.get("name", "") or "").strip()
     try:
         presets = config.save_preset(name, req.body.get("settings", {}))
     except ValueError as e:

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -599,6 +599,48 @@ def _clean_settings(updates):
     return clean
 
 
+def _reconcile_preset_binding(mid, preset, engine=None):
+    """Apply only preset defaults LlamaForge still owns for one model.
+
+    A section value is user-owned when it predates the binding or differs from
+    the last materialized snapshot.  Such values are never changed or removed.
+    Returns the delta written to models.ini.
+    """
+    engine = engine or cfg().get("active_engine", "llamacpp")
+    desired = {key: value for key, value in _clean_settings(preset).items()
+               if value is not None}
+    previous = config.get_binding_snapshot(mid, engine)
+    path = config.ini_path(engine)
+    current = config.read_sections(path).get(mid, {})
+    updates, owned = {}, {}
+
+    for key, old_value in previous.items():
+        if current.get(key) != old_value:
+            continue                    # edited or deleted manually: relinquish it
+        if key not in desired:
+            updates[key] = None
+            continue
+        new_value = desired[key]
+        owned[key] = new_value
+        if new_value != old_value:
+            updates[key] = new_value
+
+    for key, new_value in desired.items():
+        if key in previous:
+            continue
+        if key not in current:
+            updates[key] = new_value
+            owned[key] = new_value
+
+    if updates:
+        if engine == cfg().get("active_engine", "llamacpp"):
+            _apply_knobs_and_reload(mid, updates)
+        else:
+            config.set_keys(mid, updates, path)
+    config.set_binding_snapshot(mid, owned, engine)
+    return updates
+
+
 def _register_ggufs_beside(paths):
     """Add scanner-derived entries to models.ini and reload the router."""
     entries = scanner.build_entries(paths)
@@ -855,7 +897,9 @@ def post_model_delete(req):
     except backends.Unsupported as e:
         raise ApiError(400, str(e))
     if ok:
-        config.prune_binding(mid)          # a gone model keeps no binding
+        if backend.name in config.PRESET_ENGINES:
+            _reconcile_preset_binding(mid, {}, backend.name)
+            config.prune_binding(mid, backend.name)
     return (200 if ok else 500), {"ok": ok, "error": err, "backend": backend.name}
 
 
@@ -905,28 +949,41 @@ def post_presets_save(req):
     # Re-sync every model bound to this preset: editing "coding" once updates
     # all models using it - the point of binding (issue #2).
     clean = _clean_settings(presets.get(name, {}))
-    for mid in config.bindings_for_preset(name):
-        _apply_knobs_and_reload(mid, clean)
+    for engine in config.PRESET_ENGINES:
+        for mid in config.bindings_for_preset(name, engine):
+            _reconcile_preset_binding(mid, clean, engine)
     return 200, {"ok": True, "presets": presets}
 
 
 def post_presets_delete(req):
-    return 200, {"ok": config.delete_preset(req.body.get("name", ""))}
+    name = req.body.get("name", "")
+    if name in config.get_presets():
+        for engine in config.PRESET_ENGINES:
+            for mid in config.bindings_for_preset(name, engine):
+                _reconcile_preset_binding(mid, {}, engine)
+    return 200, {"ok": config.delete_preset(name)}
 
 
 def post_presets_bind(req):
     """Bind a preset as a model's default (name="" unbinds). Binding
-    materializes the preset's knobs into the model's section now; unbinding
-    leaves them in place - they're the user's once written."""
-    mid = req.body.get("model", "")
-    name = req.body.get("name", "")
+    materializes only absent knobs; unbinding removes only unchanged values
+    that LlamaForge previously materialized."""
+    mid = (req.body.get("model", "") or "").strip()
+    name = (req.body.get("name", "") or "").strip()
+    engine = cfg().get("active_engine", "llamacpp")
+    if not mid:
+        raise ApiError(400, "model id is required")
     try:
-        binds = config.bind_preset(mid, name)
+        if name:
+            preset = config.get_presets().get(name)
+            if preset is None:
+                raise ValueError(f"unknown preset: {name}")
+            _reconcile_preset_binding(mid, preset, engine)
+        else:
+            _reconcile_preset_binding(mid, {}, engine)
+        binds = config.bind_preset(mid, name, engine)
     except ValueError as e:
         raise ApiError(400, str(e))
-    if name:
-        preset = config.get_presets().get(name, {})
-        _apply_knobs_and_reload(mid, _clean_settings(preset))
     return 200, {"ok": True, "bindings": binds}
 
 
@@ -1015,6 +1072,9 @@ def post_scan_prune(req):
             router("/models/unload", "POST", {"model": mid})
         if config.remove_section(mid):
             removed.append(mid)
+            engine = cfg().get("active_engine", "llamacpp")
+            _reconcile_preset_binding(mid, {}, engine)
+            config.prune_binding(mid, engine)
     if removed:
         router("/models?reload=1")
     return 200, {"removed": removed}

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -34,7 +34,8 @@ order: 1
 | `ik_llama_cmake_flags` | object | `{}` | Persisted CMake build flags for the ik_llama build. |
 | `auto_load_model` | string | `""` | Model id to load automatically on launch. Empty string disables auto-load. |
 | `presets` | object | `{}` | Named knob sets: `{name: {knob: value}}`, managed from the dashboard. |
-| `preset_bindings` | object | `{}` | Preset bound as each model's default: `{model_id: preset_name}`. |
+| `preset_bindings` | object | `{}` | Preset bound as each model's default, scoped by llama-family engine: `{engine: {model_id: preset_name}}`. |
+| `preset_binding_snapshots` | object | `{}` | Engine-scoped values materialized by a preset binding: `{engine: {model_id: {knob: value}}}`. LlamaForge uses these snapshots to retain model values you subsequently change yourself. |
 | `ui_mode` | string | `"lite"` | `"lite"` shows a curated knob set; `"advanced"` exposes all ~220 llama-server flags. |
 | `onboarded` | bool | `False` | Whether the first-run wizard has already been shown; set to `True` once dismissed. |
 | `anthropic_default_model` | string | `""` | Fallback local model id used by the Anthropic-compatible shim when a request doesn't map to one. |
@@ -48,7 +49,17 @@ order: 1
 | `vram_predict_enabled` | bool | `True` | Whether the offline VRAM-fit/tok-s estimate is computed (Discover, on expand). |
 | `docs_dir` | string | `""` | Directory the in-app docs viewer reads from. Empty string resolves to `<repo root>/docs/content`. |
 
-35 keys total, matching `DEFAULTS` in `backend/config.py`.
+36 keys total, matching `DEFAULTS` in `backend/config.py`.
+
+## Preset bindings
+
+Binding a preset makes it the default for a model in the active llama-family
+engine (`llamacpp` or `ikllama`). When a binding is created or its preset is
+edited, LlamaForge materializes only preset knobs that the model has not set.
+`preset_binding_snapshots` records those materialized values so unbinding,
+deleting a preset, or removing a knob cleans up only values that are still
+unchanged; manual model overrides remain in `models.ini`. Older flat binding
+maps are migrated to the engine that was active when they were saved.
 
 ## Loading and saving
 

--- a/tests/test_preset_binding.py
+++ b/tests/test_preset_binding.py
@@ -135,6 +135,14 @@ class BindMaterializeRouteTest(_ConfigTempCase):
         self.assertEqual(sections["qwopus"]["temp"], "0.9")
         self.assertEqual(sections["ornith"]["temp"], "0.9")
 
+    def test_preset_edit_normalizes_name_before_resyncing_bindings(self):
+        self._post(routes.post_presets_bind, model="qwopus", name="coding")
+
+        self._post(routes.post_presets_save, name="  coding  ",
+                   settings={"temp": "0.9"})
+
+        self.assertEqual(config.read_sections()["qwopus"]["temp"], "0.9")
+
     def test_preset_edit_preserves_a_manually_changed_bound_key(self):
         self._post(routes.post_presets_bind, model="qwopus", name="coding")
         config.set_keys("qwopus", {"temp": "0.55"})

--- a/tests/test_preset_binding.py
+++ b/tests/test_preset_binding.py
@@ -1,9 +1,4 @@
-"""Bind a preset as a model's default (issue #2).
-
-A binding lives in config.json (preset_bindings: {model_id: preset_name}); the
-preset's knobs are materialized into the model's models.ini section when bound
-and re-materialized when the preset is edited. Hand edits win by write-order.
-"""
+"""Bind a preset as non-destructive model defaults (issue #2)."""
 import conftest_paths  # noqa: F401
 import json, os, tempfile, unittest
 from unittest import mock
@@ -60,10 +55,28 @@ class BindingStorageTest(_ConfigTempCase):
         self.assertTrue(config.prune_binding("qwopus"))
         self.assertEqual(config.get_bindings(), {})
 
+    def test_same_model_id_has_separate_bindings_per_engine(self):
+        config.save_preset("chat", {"temp": "0.8"})
+        config.bind_preset("shared", "coding", engine="llamacpp")
+        config.bind_preset("shared", "chat", engine="ikllama")
+
+        self.assertEqual(config.get_bindings("llamacpp"), {"shared": "coding"})
+        self.assertEqual(config.get_bindings("ikllama"), {"shared": "chat"})
+
+    def test_legacy_flat_bindings_migrate_into_the_active_engine(self):
+        cfg = config.load()
+        cfg["active_engine"] = "ikllama"
+        cfg["preset_bindings"] = {"legacy": "coding"}
+        config.save(cfg)
+
+        config.migrate()
+
+        self.assertEqual(config.get_bindings("llamacpp"), {})
+        self.assertEqual(config.get_bindings("ikllama"), {"legacy": "coding"})
+
 
 class BindMaterializeRouteTest(_ConfigTempCase):
-    """Route-level: binding writes the preset's knobs; editing the preset
-    re-materializes into every bound model."""
+    """Route-level reconciliation owns only values that it materialized."""
 
     def setUp(self):
         super().setUp()
@@ -71,13 +84,11 @@ class BindMaterializeRouteTest(_ConfigTempCase):
         cfg = config.load(); cfg["models_ini"] = self.ini; config.save(cfg)
         config.set_keys("qwopus", {"model": "/m/q.gguf"})
         config.save_preset("coding", {"temp": "0.2", "top-k": "20"})
-        self.applied = []
-        # capture materialization instead of touching a live router
-        self._orig = routes._apply_knobs_and_reload
-        routes._apply_knobs_and_reload = lambda mid, clean: self.applied.append((mid, clean)) or False
+        self.router = mock.patch.object(routes, "router", return_value=(200, {"data": []}))
+        self.router.start()
 
     def tearDown(self):
-        routes._apply_knobs_and_reload = self._orig
+        self.router.stop()
         super().tearDown()
 
     def _post(self, fn, **body):
@@ -87,31 +98,89 @@ class BindMaterializeRouteTest(_ConfigTempCase):
     def test_bind_materializes_the_preset(self):
         self._post(routes.post_presets_bind, model="qwopus", name="coding")
         self.assertEqual(config.get_bindings(), {"qwopus": "coding"})
-        self.assertEqual(len(self.applied), 1)
-        mid, clean = self.applied[0]
-        self.assertEqual(mid, "qwopus")
-        self.assertEqual(clean.get("temp"), "0.2")
+        self.assertEqual(config.read_sections()["qwopus"]["temp"], "0.2")
+
+    def test_bind_does_not_overwrite_an_existing_model_value(self):
+        config.set_keys("qwopus", {"temp": "0.7"})
+
+        self._post(routes.post_presets_bind, model="qwopus", name="coding")
+
+        section = config.read_sections()["qwopus"]
+        self.assertEqual(section["temp"], "0.7")
+        self.assertEqual(section["top-k"], "20")
+
+    def test_bind_rejects_an_empty_model_before_writing_the_registry(self):
+        with open(self.ini, encoding="utf-8") as f:
+            before = f.read()
+
+        with self.assertRaises(routes.ApiError):
+            self._post(routes.post_presets_bind, model="", name="coding")
+
+        with open(self.ini, encoding="utf-8") as f:
+            self.assertEqual(f.read(), before)
+
+    def test_bind_normalizes_model_and_preset_names_before_reconciling(self):
+        self._post(routes.post_presets_bind, model="  qwopus  ", name="  coding  ")
+
+        self.assertEqual(config.get_bindings(), {"qwopus": "coding"})
+        self.assertEqual(config.read_sections()["qwopus"]["temp"], "0.2")
 
     def test_editing_a_bound_preset_resyncs_every_model(self):
         self._post(routes.post_presets_bind, model="qwopus", name="coding")
         config.set_keys("ornith", {"model": "/m/o.gguf"})
         self._post(routes.post_presets_bind, model="ornith", name="coding")
-        self.applied.clear()
         self._post(routes.post_presets_save, name="coding", settings={"temp": "0.9"})
-        synced = {mid for mid, _ in self.applied}
-        self.assertEqual(synced, {"qwopus", "ornith"})
-        self.assertTrue(all(clean.get("temp") == "0.9" for _, clean in self.applied))
 
-    def test_unbind_leaves_knobs_in_place(self):
+        sections = config.read_sections()
+        self.assertEqual(sections["qwopus"]["temp"], "0.9")
+        self.assertEqual(sections["ornith"]["temp"], "0.9")
+
+    def test_preset_edit_preserves_a_manually_changed_bound_key(self):
         self._post(routes.post_presets_bind, model="qwopus", name="coding")
-        self.applied.clear()
+        config.set_keys("qwopus", {"temp": "0.55"})
+
+        self._post(routes.post_presets_save, name="coding",
+                   settings={"temp": "0.9", "top-k": "40"})
+
+        section = config.read_sections()["qwopus"]
+        self.assertEqual(section["temp"], "0.55")
+        self.assertEqual(section["top-k"], "40")
+
+    def test_removed_preset_key_is_deleted_only_while_still_owned(self):
+        self._post(routes.post_presets_bind, model="qwopus", name="coding")
+        config.set_keys("qwopus", {"temp": "0.55"})
+
+        self._post(routes.post_presets_save, name="coding", settings={"min-p": "0.1"})
+
+        section = config.read_sections()["qwopus"]
+        self.assertEqual(section["temp"], "0.55")
+        self.assertNotIn("top-k", section)
+        self.assertEqual(section["min-p"], "0.1")
+
+    def test_unbind_removes_untouched_owned_values_but_keeps_manual_values(self):
+        self._post(routes.post_presets_bind, model="qwopus", name="coding")
+        config.set_keys("qwopus", {"temp": "0.55"})
         self._post(routes.post_presets_bind, model="qwopus", name="")   # unbind
+
         self.assertEqual(config.get_bindings(), {})
-        self.assertEqual(self.applied, [], "unbind must not rewrite the section")
+        section = config.read_sections()["qwopus"]
+        self.assertEqual(section["temp"], "0.55")
+        self.assertNotIn("top-k", section)
 
     def test_saving_an_unbound_preset_materializes_nothing(self):
         self._post(routes.post_presets_save, name="coding", settings={"temp": "0.5"})
-        self.assertEqual(self.applied, [])
+        self.assertNotIn("temp", config.read_sections()["qwopus"])
+
+    def test_deleting_preset_removes_only_untouched_owned_values(self):
+        self._post(routes.post_presets_bind, model="qwopus", name="coding")
+        config.set_keys("qwopus", {"temp": "0.55"})
+
+        self._post(routes.post_presets_delete, name="coding")
+
+        self.assertEqual(config.get_bindings(), {})
+        section = config.read_sections()["qwopus"]
+        self.assertEqual(section["temp"], "0.55")
+        self.assertNotIn("top-k", section)
 
 
 if __name__ == "__main__":

--- a/tests/test_routes_api.py
+++ b/tests/test_routes_api.py
@@ -137,10 +137,17 @@ class ScanPruneTest(unittest.TestCase):
     whose file is actually present."""
 
     def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.old_config = config.CONFIG
+        config.CONFIG = os.path.join(self.tmp, "config.json")
         self.removed = []
         mock.patch.object(config, "remove_section",
                           side_effect=lambda s: (self.removed.append(s), True)[1]).start()
-        self.addCleanup(mock.patch.stopall)
+        self.addCleanup(self._cleanup)
+
+    def _cleanup(self):
+        mock.patch.stopall()
+        config.CONFIG = self.old_config
 
     def _no_router(self, *a, **k):
         return 599, {}
@@ -161,6 +168,17 @@ class ScanPruneTest(unittest.TestCase):
              mock.patch.object(routes, "router", self._no_router):
             status, out = routes.post_scan_prune(Req(body={"ids": ["ghost"]}))
         self.assertEqual(out["removed"], [])
+
+    def test_pruning_a_removed_section_drops_its_preset_binding(self):
+        config.save_preset("coding", {"temp": "0.2"})
+        config.bind_preset("gone", "coding")
+        with mock.patch.object(config, "read_sections",
+                               return_value={"gone": {"model": "/nope/a.gguf"}}), \
+             mock.patch.object(routes, "router", self._no_router):
+            status, out = routes.post_scan_prune(Req(body={"ids": ["gone"]}))
+
+        self.assertEqual(out["removed"], ["gone"])
+        self.assertEqual(config.get_bindings(), {})
 
 
 class HubAddTest(unittest.TestCase):

--- a/web/js/models.js
+++ b/web/js/models.js
@@ -407,8 +407,8 @@ function openClientConfig(id) {
 
 /* ---------- presets ---------- */
 function presetBar(m) {
-  const P = cfgOf().presets || {};
-  const bound = (cfgOf().preset_bindings || {})[m.id] || "";
+  const c = cfgOf(), P = c.presets || {};
+  const bound = ((c.preset_bindings || {})[m.backend || c.active_engine || "llamacpp"] || {})[m.id] || "";
   const chips = Object.keys(P).map(n => {
     const isBound = n === bound;
     return `<span class="pchip${isBound ? " bound" : ""}" data-preset-apply="${esc(n)}" data-preset-model="${esc(m.id)}" title="apply preset to this model">`
@@ -428,7 +428,8 @@ async function applyPreset(model, name) {
 }
 async function bindPreset(model, name) {
   // toggle: clicking the dot of an already-bound preset unbinds it
-  const cur = (cfgOf().preset_bindings || {})[model] || "";
+  const c = cfgOf(), engine = c.active_engine || "llamacpp";
+  const cur = ((c.preset_bindings || {})[engine] || {})[model] || "";
   const next = (cur === name) ? "" : name;
   const r = await api("/api/presets/bind", {model, name: next});
   if (r.ok) {


### PR DESCRIPTION
## Summary
- Store preset bindings and ownership snapshots per llama.cpp engine.
- Preserve explicit model overrides while reconciling edited presets and prune stale owned values.
- Document the persisted binding format and migration.

## Tests
- C:\Users\AppData\Local\Programs\Python\Python314\python.exe -m unittest discover -s . -p test_*.py (453 tests)

Closes #2