### PR TITLE
fix: auto-wire MTP sidecar models

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -48,6 +48,7 @@ DEFAULTS = {
     "auto_load_model": "",                    # model id to load automatically on launch ("" = none)
     "presets":     {},                       # named knob sets: {name: {knob: value}}
     "preset_bindings": {},                    # {model_id: preset_name} auto-applied on bind/edit
+    "mtp_auto_owned": {},                     # {engine: {model_id: {key: value}}}
     "ui_mode":     "lite",                    # "lite" (curated knobs) or "advanced" (all ~220)
     "onboarded":   False,                     # first-run wizard shown once, then True
     "anthropic_default_model": "",           # fallback local model id for the Anthropic shim
@@ -300,6 +301,60 @@ def remove_section(section, path=None):
     path = path or ini_path()
     with _INI_LOCK:
         return _remove_section_locked(section, path)
+
+# ---------------- automatic MTP wiring ----------------
+
+def reconcile_mtp_autowire(model_id, current, desired):
+    """Return safe models.ini updates and record the values LlamaForge owns.
+
+    ``desired`` contains speculative keys inferred by a scan. Previously
+    auto-written values may be replaced or removed while unchanged; a missing,
+    different, or manually deleted value is treated as a user override.
+    Ownership is engine-scoped because each llama family has its own registry.
+    """
+    current = current or {}
+    desired = desired or {}
+
+    with _LOCK:
+        cfg = load()
+        engine = cfg.get("active_engine", "llamacpp")
+        all_owned = cfg.get("mtp_auto_owned")
+        if not isinstance(all_owned, dict):
+            all_owned = {}
+        before_owned = copy.deepcopy(all_owned)
+        engine_owned = all_owned.get(engine)
+        if not isinstance(engine_owned, dict):
+            engine_owned = {}
+        prior = engine_owned.get(model_id)
+        if not isinstance(prior, dict) or "model" not in current:
+            prior = {}
+
+        updates, next_owned = {}, {}
+        for key in ("spec-draft-model", "spec-type"):
+            want = desired.get(key)
+            before = prior.get(key)
+            actual = current.get(key)
+            if key in prior:
+                if actual == before:
+                    updates[key] = want
+                    if want is not None:
+                        next_owned[key] = str(want)
+            elif want is not None and not actual:
+                updates[key] = want
+                next_owned[key] = str(want)
+
+        if next_owned:
+            engine_owned[model_id] = next_owned
+        else:
+            engine_owned.pop(model_id, None)
+        if engine_owned:
+            all_owned[engine] = engine_owned
+        else:
+            all_owned.pop(engine, None)
+        if all_owned != before_owned:
+            cfg["mtp_auto_owned"] = all_owned
+            save(cfg)
+        return updates
 
 def _remove_section_locked(section, path):
     if not path or not os.path.exists(path):

--- a/backend/hub.py
+++ b/backend/hub.py
@@ -7,6 +7,8 @@ no SSL support).
 """
 import json, os, re, threading, time, urllib.request, urllib.parse
 
+import scanner
+
 HF = "https://huggingface.co"
 UA = {"User-Agent": "LlamaForge/1.0 (+local model manager)"}
 
@@ -53,11 +55,14 @@ def files(repo, vram_mib=0):
     """List a repo's GGUF files with size + fit rating. Collapses shard sets."""
     tree = _get_json(f"{HF}/api/models/{repo}/tree/main")
     ggufs = [f for f in tree if f.get("path", "").lower().endswith(".gguf")]
-    shard_totals, singles, mmproj = {}, [], []
+    shard_totals, singles, mmproj, mtp = {}, [], [], []
     for f in ggufs:
         p, size = f["path"], f.get("size", 0)
         if os.path.basename(p).lower().startswith("mmproj"):
             mmproj.append({"path": p, "size": size})
+            continue
+        if os.path.basename(p).lower().startswith("mtp-"):
+            mtp.append({"path": p, "size": size})
             continue
         m = re.search(r"-(\d{5})-of-(\d{5})\.gguf$", p, re.I)
         if m:
@@ -77,7 +82,13 @@ def files(repo, vram_mib=0):
             out.append({"path": agg["first"], "size": agg["size"], "shards": agg["n"],
                         "fit": _fit(agg["size"], vram_mib)})
     out.sort(key=lambda x: x["size"])
-    return {"files": out, "mmproj": sorted(mmproj, key=lambda x: x["size"])}
+    mtp.sort(key=lambda x: x["size"])
+    pairs = scanner.mtp_pairs([f["path"] for f in out], [f["path"] for f in mtp])
+    for f in out:
+        if f["path"] in pairs:
+            f["mtp"] = pairs[f["path"]]
+    return {"files": out, "mmproj": sorted(mmproj, key=lambda x: x["size"]),
+            "mtp": mtp}
 
 def shard_paths(first_path, n):
     """All shard file paths given the first shard's path."""

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -599,16 +599,28 @@ def _clean_settings(updates):
     return clean
 
 
+def _persist_scanned_entries(entries):
+    """Persist scanner fields and reconcile only LlamaForge-owned MTP keys."""
+    existing = config.read_sections()
+    for e in entries:
+        keys = {
+            "model": e["model"],
+            "mmproj": e.get("mmproj") or None,
+            "embeddings": "true" if e.get("embeddings") else None,
+        }
+        desired_mtp = {
+            "spec-draft-model": e.get("draft_model"),
+            "spec-type": "draft-mtp" if e.get("draft_mtp") else None,
+        }
+        keys.update(config.reconcile_mtp_autowire(
+            e["id"], existing.get(e["id"]), desired_mtp))
+        config.set_keys(e["id"], keys)
+    return entries
+
+
 def _register_ggufs_beside(paths):
     """Add scanner-derived entries to models.ini and reload the router."""
-    entries = scanner.build_entries(paths)
-    for e in entries:
-        keys = {"model": e["model"]}
-        if e.get("mmproj"):
-            keys["mmproj"] = e["mmproj"]
-        if e.get("embeddings"):
-            keys["embeddings"] = "true"
-        config.set_keys(e["id"], keys)
+    entries = _persist_scanned_entries(scanner.build_entries(paths))
     config.apply_ctx_defaults()
     router("/models?reload=1")
     return entries
@@ -978,22 +990,7 @@ def post_scan(req):
 
 def post_scan_apply(req):
     entries = req.body.get("entries", [])
-    existing = config.read_sections()
-    for e in entries:
-        keys = {"model": e["model"]}
-        # Always pass mmproj/embeddings so stale values are cleared on re-scan.
-        keys["mmproj"] = e.get("mmproj") or None
-        keys["embeddings"] = "true" if e.get("embeddings") else None
-        # MTP wiring is ADDITIVE, unlike mmproj: spec-type is also how the user
-        # selects ngram-* speculation, so clearing it on re-scan would wipe a
-        # hand-set mode. Only fill these when the section doesn't already carry
-        # its own value.
-        sect = existing.get(e["id"], {})
-        if e.get("draft_model") and not sect.get("spec-draft-model"):
-            keys["spec-draft-model"] = e["draft_model"]
-        if e.get("draft_mtp") and not sect.get("spec-type"):
-            keys["spec-type"] = "draft-mtp"
-        config.set_keys(e["id"], keys)
+    _persist_scanned_entries(entries)
     config.apply_ctx_defaults()
     router("/models?reload=1")
     return 200, {"ok": True, "added": len(entries)}
@@ -1048,7 +1045,7 @@ def post_hub_files(req):
                     f["fit"] = label
         return 200, listing
     except Exception as e:
-        return 200, {"error": str(e), "files": [], "mmproj": []}
+        return 200, {"error": str(e), "files": [], "mmproj": [], "mtp": []}
 
 
 def post_vram_predict(req):
@@ -1086,6 +1083,8 @@ def post_hub_download(req):
     paths  = hub.shard_paths(first, shards)
     if req.body.get("mmproj"):
         paths.append(req.body["mmproj"])
+    if req.body.get("mtp"):
+        paths.append(req.body["mtp"])
     dest = os.path.join(download_dir(), repo.replace("/", "--"))
     ok = DOWNLOADS.start(repo, paths, dest)
     return 200, {"started": ok, "dest": dest}

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -602,7 +602,22 @@ def _clean_settings(updates):
 def _persist_scanned_entries(entries):
     """Persist scanner fields and reconcile only LlamaForge-owned MTP keys."""
     existing = config.read_sections()
-    
+    for e in entries:
+        keys = {
+            "model": e["model"],
+            "mmproj": e.get("mmproj") or None,
+            "embeddings": "true" if e.get("embeddings") else None,
+        }
+        desired_mtp = {
+            "spec-draft-model": e.get("draft_model"),
+            "spec-type": "draft-mtp" if e.get("draft_mtp") else None,
+        }
+        keys.update(config.reconcile_mtp_autowire(
+            e["id"], existing.get(e["id"]), desired_mtp))
+        config.set_keys(e["id"], keys)
+    return entries
+
+
 def _reconcile_preset_binding(mid, preset, engine=None):
     """Apply only preset defaults LlamaForge still owns for one model.
 
@@ -643,25 +658,6 @@ def _reconcile_preset_binding(mid, preset, engine=None):
             config.set_keys(mid, updates, path)
     config.set_binding_snapshot(mid, owned, engine)
     return updates
-
-
-def _register_ggufs_beside(paths):
-    """Add scanner-derived entries to models.ini and reload the router."""
-    entries = scanner.build_entries(paths)
-    for e in entries:
-        keys = {
-            "model": e["model"],
-            "mmproj": e.get("mmproj") or None,
-            "embeddings": "true" if e.get("embeddings") else None,
-        }
-        desired_mtp = {
-            "spec-draft-model": e.get("draft_model"),
-            "spec-type": "draft-mtp" if e.get("draft_mtp") else None,
-        }
-        keys.update(config.reconcile_mtp_autowire(
-            e["id"], existing.get(e["id"]), desired_mtp))
-        config.set_keys(e["id"], keys)
-    return entries
 
 
 def _register_ggufs_beside(paths):

--- a/backend/scanner.py
+++ b/backend/scanner.py
@@ -77,15 +77,49 @@ def _shard(p):
     m = re.search(r"-(\d{5})-of-(\d{5})\.gguf$", _base(p), re.I)
     return (m.group(1), m.group(2)) if m else None
 
+def _model_stem(p):
+    """Normalized logical basename, with a shard suffix removed."""
+    return re.sub(r"-\d{5}-of-\d{5}$", "", _slug(_base(p)), flags=re.I)
+
+def mtp_pairs(mains, sidecars):
+    """Return {main_path: mtp_path} for unambiguous same-directory pairs.
+
+    An exact normalized ``mtp-<main basename>`` match wins. A generic sidecar
+    is safe only when its directory contains exactly one main and one sidecar.
+    """
+    mains_by_dir, sidecars_by_dir = defaultdict(list), defaultdict(list)
+    for path in mains:
+        mains_by_dir[os.path.dirname(path)].append(path)
+    for path in sidecars:
+        sidecars_by_dir[os.path.dirname(path)].append(path)
+
+    pairs = {}
+    for directory, dir_mains in mains_by_dir.items():
+        dir_sidecars = sidecars_by_dir.get(directory, [])
+        candidates = defaultdict(list)
+        for sidecar in dir_sidecars:
+            tail = _model_stem(sidecar)
+            if tail.startswith("mtp-"):
+                tail = tail[4:]
+            matches = [main for main in dir_mains if _model_stem(main) == tail]
+            if len(matches) == 1:
+                candidates[matches[0]].append(sidecar)
+        for main, matches in candidates.items():
+            if len(matches) == 1:
+                pairs[main] = matches[0]
+        if not pairs.keys() & set(dir_mains) and len(dir_mains) == 1 and len(dir_sidecars) == 1:
+            pairs[dir_mains[0]] = dir_sidecars[0]
+    return pairs
+
 def build_entries(paths):
     """Return list of {id, model, mmproj?, embeddings?, gib, existing_id?}."""
     mmproj_by_dir = {}
-    mtp_by_dir = {}
+    mtp_sidecars = []
     for p in paths:
         if _is_mmproj(p):
             mmproj_by_dir[os.path.dirname(p)] = p
         elif _is_mtp(p):
-            mtp_by_dir[os.path.dirname(p)] = p
+            mtp_sidecars.append(p)
 
     mains = []
     seen_shard_sets = set()
@@ -99,6 +133,8 @@ def build_entries(paths):
                 continue  # only the first shard represents the set
             seen_shard_sets.add(key)
         mains.append(p)
+
+    mtp_by_main = mtp_pairs(mains, mtp_sidecars)
 
     stem_counts = defaultdict(int)
     for p in mains:
@@ -127,7 +163,7 @@ def build_entries(paths):
         # Attach an mtp-* sibling as a speculative draft model. Attaching alone
         # is inert; only enable spec-type=draft-mtp when the sidecar actually
         # declares NextN layers, the signal llama.cpp itself gates on.
-        mt = mtp_by_dir.get(os.path.dirname(p))
+        mt = mtp_by_main.get(p)
         if mt:
             from gguf import has_nextn
             e["draft_model"] = mt.replace("\\", "/")

--- a/tests/test_hub_resume.py
+++ b/tests/test_hub_resume.py
@@ -1,7 +1,8 @@
 import conftest_paths  # noqa: F401
 import os, tempfile, threading, unittest
+from unittest import mock
 import urllib.request
-import hub
+import hub, routes
 
 
 class FakeResp:
@@ -91,6 +92,41 @@ class TestResume(unittest.TestCase):
 
     def test_resume_refused_when_no_paused_job(self):
         self.assertFalse(hub.DownloadManager().resume())
+
+
+class HubMtpSidecarTest(unittest.TestCase):
+    def test_files_separates_mtp_and_pairs_only_the_matching_main(self):
+        tree = [
+            {"path": "alpha-q4.gguf", "size": 4},
+            {"path": "beta-q4.gguf", "size": 5},
+            {"path": "mtp-beta-q4.gguf", "size": 1},
+        ]
+        with mock.patch.object(hub, "_get_json", return_value=tree):
+            result = hub.files("owner/repo")
+
+        self.assertEqual(result["mtp"],
+                         [{"path": "mtp-beta-q4.gguf", "size": 1}])
+        choices = {f["path"]: f for f in result["files"]}
+        self.assertNotIn("mtp", choices["alpha-q4.gguf"])
+        self.assertEqual(choices["beta-q4.gguf"]["mtp"], "mtp-beta-q4.gguf")
+
+    def test_download_includes_selected_mtp_sidecar(self):
+        seen = {}
+
+        def start(repo, paths, dest):
+            seen.update(repo=repo, paths=paths, dest=dest)
+            return True
+
+        req = mock.Mock()
+        req.body = {"repo": "owner/repo", "path": "beta-q4.gguf",
+                    "shards": 1, "mtp": "mtp-beta-q4.gguf"}
+        with mock.patch.object(routes.DOWNLOADS, "start", side_effect=start), \
+             mock.patch.object(routes, "download_dir", return_value="/downloads"):
+            status, result = routes.post_hub_download(req)
+
+        self.assertEqual(status, 200)
+        self.assertTrue(result["started"])
+        self.assertEqual(seen["paths"], ["beta-q4.gguf", "mtp-beta-q4.gguf"])
 
 
 if __name__ == "__main__":

--- a/tests/test_mtp_autowire.py
+++ b/tests/test_mtp_autowire.py
@@ -81,6 +81,27 @@ class BuildEntriesMtpTest(unittest.TestCase):
         (entry,) = self._entries(paths, nextn=True).values()
         self.assertNotIn("draft_model", entry)
 
+    def test_matching_sidecar_attaches_only_to_its_main_in_a_multi_model_dir(self):
+        entries = self._entries([
+            "/m/alpha-q4.gguf", "/m/beta-q4.gguf", "/m/mtp-beta-q4.gguf",
+        ], nextn=True)
+        self.assertNotIn("draft_model", entries["alpha-q4.gguf"])
+        self.assertEqual(entries["beta-q4.gguf"]["draft_model"],
+                         "/m/mtp-beta-q4.gguf")
+
+    def test_generic_sidecar_attaches_to_none_in_a_multi_model_dir(self):
+        entries = self._entries([
+            "/m/alpha-q4.gguf", "/m/beta-q4.gguf", "/m/mtp-draft.gguf",
+        ], nextn=True)
+        self.assertNotIn("draft_model", entries["alpha-q4.gguf"])
+        self.assertNotIn("draft_model", entries["beta-q4.gguf"])
+
+    def test_generic_sidecar_attaches_when_directory_has_one_main(self):
+        (entry,) = self._entries([
+            "/m/alpha-q4.gguf", "/m/mtp-draft.gguf",
+        ], nextn=True).values()
+        self.assertEqual(entry["draft_model"], "/m/mtp-draft.gguf")
+
 
 class ScanApplyMtpTest(unittest.TestCase):
     """Route-level: additive wiring that never clobbers a hand-set spec-type."""
@@ -128,6 +149,69 @@ class ScanApplyMtpTest(unittest.TestCase):
         sect = config.read_sections()["m"]
         self.assertEqual(sect["spec-draft-model"], "/m/mtp-m.gguf")
         self.assertNotIn("spec-type", sect)
+
+    def test_rescan_replaces_then_removes_unchanged_auto_owned_draft_keys(self):
+        self._apply([{"id": "m", "model": "/m/m.gguf",
+                      "draft_model": "/m/mtp-old.gguf", "draft_mtp": True}])
+        self._apply([{"id": "m", "model": "/m/m.gguf",
+                      "draft_model": "/m/mtp-new.gguf", "draft_mtp": True}])
+        replaced = config.read_sections()["m"]
+        self.assertEqual(replaced["spec-draft-model"], "/m/mtp-new.gguf")
+        self.assertEqual(replaced["spec-type"], "draft-mtp")
+
+        self._apply([{"id": "m", "model": "/m/m.gguf"}])
+        removed = config.read_sections()["m"]
+        self.assertNotIn("spec-draft-model", removed)
+        self.assertNotIn("spec-type", removed)
+
+    def test_rescan_never_replaces_or_removes_a_manually_edited_draft_key(self):
+        self._apply([{"id": "m", "model": "/m/m.gguf",
+                      "draft_model": "/m/mtp-auto.gguf", "draft_mtp": True}])
+        config.set_keys("m", {"spec-draft-model": "/m/manual-draft.gguf"})
+
+        self._apply([{"id": "m", "model": "/m/m.gguf",
+                      "draft_model": "/m/mtp-new.gguf", "draft_mtp": True}])
+        self.assertEqual(config.read_sections()["m"]["spec-draft-model"],
+                         "/m/manual-draft.gguf")
+
+        self._apply([{"id": "m", "model": "/m/m.gguf"}])
+        self.assertEqual(config.read_sections()["m"]["spec-draft-model"],
+                         "/m/manual-draft.gguf")
+
+
+class HubRegistrationMtpTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self._saved = config.CONFIG
+        config.CONFIG = os.path.join(self.tmp, "config.json")
+        self.ini = os.path.join(self.tmp, "models.ini")
+        with open(config.CONFIG, "w") as f:
+            json.dump({"models_ini": self.ini}, f)
+
+    def tearDown(self):
+        config.CONFIG = self._saved
+
+    def test_post_download_registration_persists_mtp_draft_keys(self):
+        folder = os.path.join(self.tmp, "repo")
+        os.makedirs(folder)
+        main = os.path.join(folder, "qwen-q4.gguf")
+        sidecar = os.path.join(folder, "mtp-qwen-q4.gguf")
+        open(main, "wb").close()
+        open(sidecar, "wb").close()
+
+        req = mock.Mock()
+        req.body = {"path": main}
+        with mock.patch("gguf.has_nextn", return_value=True), \
+             mock.patch.object(config, "apply_ctx_defaults",
+                               return_value={"changed": []}), \
+             mock.patch.object(routes, "router", return_value=(200, {})):
+            status, result = routes.post_hub_add(req)
+
+        self.assertEqual(status, 200)
+        self.assertEqual(result["added"], ["qwen-q4"])
+        section = config.read_sections()["qwen-q4"]
+        self.assertEqual(section["spec-draft-model"], sidecar.replace("\\", "/"))
+        self.assertEqual(section["spec-type"], "draft-mtp")
 
 
 if __name__ == "__main__":

--- a/web/js/discover.js
+++ b/web/js/discover.js
@@ -164,20 +164,21 @@ async function hubFiles(row) {
   const mm = r.mmproj && r.mmproj.length ? r.mmproj[0].path : "";
   setHTML(box, `
     ${mm?`<div class="note">vision model - the smallest mmproj (${esc(mm)}) will be downloaded too</div>`:""}
+    ${r.mtp&&r.mtp.length?`<div class="note">matching MTP sidecars are downloaded automatically</div>`:""}
     <div class="list" style="margin-top:8px">${r.files.map(f=>`
       <div class="row"><div class="rhead" style="grid-template-columns:1fr auto auto auto auto;cursor:default">
-        <span class="mid">${esc(f.path)}${f.shards>1?`<span class="tag">${f.shards} shards</span>`:""}</span>
+        <span class="mid">${esc(f.path)}${f.shards>1?`<span class="tag">${f.shards} shards</span>`:""}${f.mtp?`<span class="tag" title="includes ${esc(f.mtp)}">MTP</span>`:""}</span>
         <span class="ctxpill">${esc((f.size/1e9).toFixed(2))} GB</span>
         ${fitBadge(f.fit)}
         ${predictBadge(f.predict)}
-        <button data-dl="${esc(f.path)}" data-shards="${f.shards}" ${f.fit==="offload"?'title="larger than VRAM - will be slow"':""}>Download</button>
+        <button data-dl="${esc(f.path)}" data-shards="${f.shards}" data-mtp="${esc(f.mtp||"")}" ${f.fit==="offload"?'title="larger than VRAM - will be slow"':""}>Download</button>
       </div></div>`).join("")}</div>`);
   $$("[data-dl]", box).forEach(b => b.onclick = () =>
-    hubDownload(row.dataset.repo, b.dataset.dl, parseInt(b.dataset.shards), mm));
+    hubDownload(row.dataset.repo, b.dataset.dl, parseInt(b.dataset.shards), mm, b.dataset.mtp));
 }
 
-async function hubDownload(repo, path, shards, mmproj) {
-  const r = await api("/api/hub/download", {repo, path, shards, mmproj});
+async function hubDownload(repo, path, shards, mmproj, mtp) {
+  const r = await api("/api/hub/download", {repo, path, shards, mmproj, mtp});
   if (!r.started) { toast("A download is already running", "err"); return; }
   toast("Download started", "ok");
   $("#hub-dlcard").style.display = ""; $("#dl-done").style.display = "none";

--- a/web/js/discover.js
+++ b/web/js/discover.js
@@ -164,7 +164,7 @@ async function hubFiles(row) {
   const mm = r.mmproj && r.mmproj.length ? r.mmproj[0].path : "";
   setHTML(box, `
     ${mm?`<div class="note">vision model - the smallest mmproj (${esc(mm)}) will be downloaded too</div>`:""}
-    ${r.mtp&&r.mtp.length?`<div class="note">matching MTP sidecars are downloaded automatically</div>`:""}
+    ${r.files.some(f=>f.mtp)?`<div class="note">matching MTP sidecars are downloaded automatically</div>`:""}
     <div class="list" style="margin-top:8px">${r.files.map(f=>`
       <div class="row"><div class="rhead" style="grid-template-columns:1fr auto auto auto auto;cursor:default">
         <span class="mid">${esc(f.path)}${f.shards>1?`<span class="tag">${f.shards} shards</span>`:""}${f.mtp?`<span class="tag" title="includes ${esc(f.mtp)}">MTP</span>`:""}</span>


### PR DESCRIPTION
## Summary
- Detect and pair MTP draft-model sidecars conservatively.
- Download and persist paired MTP sidecars through both Hub and scan flows without overwriting manual settings.
- Show automatic-download guidance only when a main file has a real pairing.

## Tests
- C:\Users\AppData\Local\Programs\Python\Python314\python.exe -m unittest discover -s . -p test_*.py (451 tests)

Closes #3