### PR TITLE
fix(vram): model Apple unified memory locally

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -89,11 +89,8 @@ gets built next.
 
 ## Planned
 
-- **Community VRAM-fit reports** — the fit rating is now offload-aware
-  ([#4](https://github.com/dadwritestech/LlamaForge/issues/4) part 1). The
-  remaining half is a crowdsourced signal ("this quant runs at ~X tok/s on a
-  16 GB card") to sit alongside the physics estimate. It can't be local-only, so
-  it needs its own design (hosting, opt-in, moderation) before any build.
+- **Local-only VRAM-fit predictions** — fit ratings remain entirely on-device.
+  LlamaForge will not build hosted or crowdsourced performance reporting.
 - **Native (non-WSL) vLLM on Linux** — vLLM currently rides WSL2 on Windows only.
 
 ## Under consideration

--- a/backend/vram_predict.py
+++ b/backend/vram_predict.py
@@ -8,7 +8,7 @@ input degrades to a lower-confidence result with a plain-language note.
 """
 import json, os, re, threading, urllib.request
 
-import config, hardware, gguf
+import config, hardware, gguf, osplat
 from vramwise import physics, catalog, constants as C
 
 HF = "https://huggingface.co"
@@ -37,8 +37,17 @@ def build_hardware(cfg=None, gpus=None, ram_gb=None):
     gpus = hardware.detect_gpus() if gpus is None else gpus
     vram_mib = sum((g.get("vram_mib") or 0) for g in gpus)
     ram_gb = hardware.detect_ram_gb() if ram_gb is None else ram_gb
-    ram_gb = ram_gb or 16.0
     name = gpus[0]["name"] if gpus else "cpu"
+    apple_unified = False
+    if osplat.IS_MAC:
+        mem_bytes = osplat.mac_mem_bytes()
+        if mem_bytes:
+            name = "Apple Silicon (unified memory)"
+            vram_mib = mem_bytes * osplat.METAL_BUDGET / (1024 * 1024)
+            ram_gb = 0.0
+            apple_unified = True
+    if not apple_unified:
+        ram_gb = ram_gb or 16.0
     ov = (cfg or {}).get("vram_bandwidths") or {}
     return physics.Hardware(
         name=name,

--- a/backend/vram_predict.py
+++ b/backend/vram_predict.py
@@ -34,12 +34,13 @@ def build_hardware(cfg=None, gpus=None, ram_gb=None):
     """Assemble a vramwise Hardware from detection + config overrides.
     gpus/ram_gb are injectable for tests; None triggers real detection."""
     cfg = cfg if cfg is not None else config.load()
+    auto_detect = gpus is None and ram_gb is None
     gpus = hardware.detect_gpus() if gpus is None else gpus
     vram_mib = sum((g.get("vram_mib") or 0) for g in gpus)
     ram_gb = hardware.detect_ram_gb() if ram_gb is None else ram_gb
     name = gpus[0]["name"] if gpus else "cpu"
     apple_unified = False
-    if osplat.IS_MAC:
+    if osplat.IS_MAC and auto_detect:
         mem_bytes = osplat.mac_mem_bytes()
         if mem_bytes:
             name = "Apple Silicon (unified memory)"

--- a/tests/test_routes_hub_predict.py
+++ b/tests/test_routes_hub_predict.py
@@ -9,7 +9,7 @@ class TestHubFilesPredict(unittest.TestCase):
         self._pred = vram_predict.predict_remote
         self._load = config.load
         hub.files = lambda repo, vram: {
-            "files": [{"path": "M-Q4_K_M.gguf", "size": int(20e9), "shards": 1, "fit": "tight"}],
+            "files": [{"path": "M-Q4_K_M.gguf", "size": int(20e9), "shards": 1, "fit": "offload"}],
             "mmproj": []}
         vram_predict.predict_remote = lambda **kw: {
             "regime": "hybrid", "tok_s": 21.0, "confidence": "high", "note": "ok",
@@ -28,6 +28,12 @@ class TestHubFilesPredict(unittest.TestCase):
         f0 = payload["files"][0]
         self.assertIn("predict", f0)
         self.assertEqual(f0["predict"]["regime"], "hybrid")
+
+    def test_usable_hybrid_prediction_replaces_naive_offload_label(self):
+        status, payload = routes.post_hub_files(routes.Req(body={"repo": "acme/model"}))
+
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["files"][0]["fit"], "tight")
 
     def test_disabled_toggle_omits_prediction(self):
         config.load = lambda: {"vram_predict_enabled": False}

--- a/tests/test_vram_predict.py
+++ b/tests/test_vram_predict.py
@@ -1,6 +1,7 @@
 import conftest_paths  # noqa: F401
 import unittest
 import vram_predict as vp
+import osplat
 from vramwise import constants as C
 
 
@@ -21,6 +22,20 @@ class TestBuildHardware(unittest.TestCase):
         self.assertEqual(hw.vram_bw, 1008)
         self.assertAlmostEqual(hw.vram_gb, 24.0, delta=0.1)
         self.assertEqual(hw.ram_gb, 64.0)
+
+    def test_apple_silicon_uses_metal_budget_without_ram_spill(self):
+        original_is_mac = osplat.IS_MAC
+        original_mem = osplat.mac_mem_bytes
+        osplat.IS_MAC = True
+        osplat.mac_mem_bytes = lambda: 32 * 1024 ** 3
+        try:
+            hw = vp.build_hardware(cfg={})
+        finally:
+            osplat.IS_MAC = original_is_mac
+            osplat.mac_mem_bytes = original_mem
+
+        self.assertAlmostEqual(hw.vram_gb, 32 * osplat.METAL_BUDGET, places=1)
+        self.assertEqual(hw.ram_gb, 0.0)
 
 
 class TestPredictLocal(unittest.TestCase):

--- a/tests/test_vram_predict.py
+++ b/tests/test_vram_predict.py
@@ -37,6 +37,25 @@ class TestBuildHardware(unittest.TestCase):
         self.assertAlmostEqual(hw.vram_gb, 32 * osplat.METAL_BUDGET, places=1)
         self.assertEqual(hw.ram_gb, 0.0)
 
+    def test_explicit_hardware_inputs_are_not_replaced_on_macos(self):
+        original_is_mac = osplat.IS_MAC
+        original_mem = osplat.mac_mem_bytes
+        osplat.IS_MAC = True
+        osplat.mac_mem_bytes = lambda: 32 * 1024 ** 3
+        try:
+            hw = vp.build_hardware(
+                cfg={},
+                gpus=[{"name": "RTX 4090", "vram_mib": 24576}],
+                ram_gb=64.0,
+            )
+        finally:
+            osplat.IS_MAC = original_is_mac
+            osplat.mac_mem_bytes = original_mem
+
+        self.assertAlmostEqual(hw.vram_gb, 24.0, delta=0.1)
+        self.assertEqual(hw.ram_gb, 64.0)
+        self.assertEqual(hw.vram_bw, 1008)
+
 
 class TestPredictLocal(unittest.TestCase):
     def _hw(self):


### PR DESCRIPTION
## Summary
- Model Apple unified memory locally in VRAM-fit prediction.
- Prevent unified memory from being double-counted as RAM spill.
- Retire the hosted/community-report direction; predictions remain local only.

## Tests
- C:\Users\AppData\Local\Programs\Python\Python314\python.exe -m unittest discover -s . -p test_*.py (445 tests)

Closes #4