### PR TITLE
Harden network controls and add human-scale usage stats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,5 @@ jobs:
           node-version: "20"
       - name: Check every frontend module parses
         run: for f in web/js/*.js; do node --check "$f" || exit 1; done
+      - name: Run frontend behavior tests
+        run: node --test tests/*.mjs

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Small things that add up when you use it every day:
 - **Inline failure diagnosis** — a failed load parses the router log and shows the real error plus a concrete suggested fix (e.g. "lower n-gpu-layers from 99").
 - **GGUF metadata card** — architecture, parameter size, quant, trained context, layers, heads, and rope, read straight from the file header.
 - **Compare** — pick 2–3 models and see their settings side-by-side with the differences highlighted.
-- **Client config** — one click gives you a copy-paste `curl`, OpenAI-client env vars, and a test JSON payload wired to that model's endpoint and API key.
+- **Client config** — one explicit, no-store action gives you a copy-paste `curl`, OpenAI-client env vars, and a test JSON payload wired to that model's endpoint and API key; the key is not ambient dashboard state.
 - **Download pause/resume** — a 25 GB download that gets interrupted resumes from where it stopped via an HTTP range request.
 - **Auto-load on launch** — pick a favourite model in Setup and it loads itself once the router is ready.
 - **Persistent UI** — the expanded row, unsaved edits, favourites, and last Discover search all survive tab switches and reloads.
@@ -216,8 +216,8 @@ All machine-specific paths live in `config.json` (see `config.example.json`):
 | `models_ini` | the router preset file LlamaForge edits |
 | `model_dirs` | directories to scan for GGUFs (empty = all fixed drives) |
 | `router_port` / `panel_port` | ports for llama.cpp and the dashboard |
-| `router_host` | `127.0.0.1` (default, local only) or `0.0.0.0` (reachable on your LAN) |
-| `router_api_key` | key clients send as `Authorization: Bearer <key>`; strongly recommended (and enforceable) whenever `router_host` isn't `127.0.0.1` |
+| `router_host` | `127.0.0.1` (default, local only) or `0.0.0.0` (LAN); these are the only scopes the Network Access UI configures. |
+| `router_api_key` | plaintext key clients send as `Authorization: Bearer <key>`; a usable key is required for LAN and is not returned in routine dashboard state. |
 | `auto_load_model` | model id to load automatically once the router is ready on launch (`""` = none) |
 | `presets` | named knob sets applied from the Models tab, e.g. `{"coding": {"temp": "0.2"}}` |
 | `wsl_distro` | WSL distro that runs vLLM (`""` = auto-pick the default) — Windows only |
@@ -231,12 +231,15 @@ Most of these are managed from the dashboard (Setup, Build, the Models view, and
 sidebar controls), so you rarely edit `config.json` by hand. The full key list is in
 the in-app **Help** (config.json Reference).
 
-By default everything binds to `127.0.0.1` only. The Setup tab has a **Network
-Access** panel to opt into serving the llama.cpp API/chat UI to other devices on
-your network (e.g. `http://192.168.1.x:8080/`) and restarts the router for you,
-no manual editing needed. A **Require an API key** toggle (on by default) blocks
-LAN access until you set or generate a key; leaving it unchecked exposes the
-router unauthenticated. See [SECURITY.md](SECURITY.md).
+By default everything binds to `127.0.0.1` only. The Setup tab's **Network
+Access** panel can expose only the llama.cpp router at `0.0.0.0` (for example,
+`http://192.168.1.x:8080/`); the dashboard stays loopback-only. LAN always needs
+a usable key, and every LlamaForge-owned start fails closed until that requirement
+is met. Choose explicitly to keep the current key, generate/rotate one, replace
+it, or (for local access only) clear it. Rotation invalidates existing clients;
+switching back to local keeps the key unless you explicitly confirm removal.
+Historical unsupported hosts or unsafe LAN keys remain visible for repair rather
+than being rewritten automatically. See [SECURITY.md](SECURITY.md).
 
 ## How it works
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,8 +46,9 @@ The panel treats every HTTP request as untrusted input:
 
 - Host and Origin checks keep requests tied to this loopback service and defend
   against cross-site requests and DNS rebinding.
-- State-changing requests require JSON content type; this is defense in depth
-  against form posts.
+- When a POST declares `Content-Type`, it must be `application/json`; declared
+  form or other non-JSON types are rejected with 415. This is defense in depth
+  against form posts. A missing `Content-Type` is not rejected by this guard.
 - POST framing requires one valid `Content-Length`; transfer encoding, malformed
   or duplicate lengths, short bodies, and oversized requests are rejected and
   the connection is closed. Management JSON is capped at 4 MiB; the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,79 +1,71 @@
 # Security
 
-## Default: local only
+## Control plane and router scope
 
-By default, both processes bind to `127.0.0.1` and are not reachable from
-your network:
+The LlamaForge dashboard and its management API always bind to `127.0.0.1`
+(the `panel_port`, default `8090`). They are a local control plane and are not
+made reachable on the LAN. The separate llama.cpp router (`router_port`, default
+`8080`) has just two LlamaForge-managed scopes: local `127.0.0.1` or LAN
+`0.0.0.0`.
 
-- The LlamaForge dashboard (`backend/server.py`), on `panel_port` (default 8090).
-- The llama.cpp router (`llama-server.exe --models-preset ...`), on `router_port`
-  (default 8080).
+The Setup tab's **Network Access** card changes the router scope, not the
+dashboard. Use remote desktop or SSH to administer LlamaForge from another
+machine; do not expose the panel port.
 
-## Opt-in: LAN access for the router
+## LAN access fails closed
 
-The Setup tab's **Network Access** panel lets you switch the llama.cpp
-router's bind address from `127.0.0.1` to `0.0.0.0`, making it reachable from
-other devices on your network (e.g. to use the chat UI from your phone, or
-point another machine's OpenAI-compatible client at it).
+Every newly configured LAN router requires a usable API key, and every
+LlamaForge-owned router start or restart repeats that policy check before it
+stops or starts a process. There is no unauthenticated-LAN override. Clients use
+`Authorization: Bearer <key>` when the upstream router requires it.
 
-When enabled:
+Network Access has explicit key actions: keep the current key, generate a new
+key, replace it, or clear it (clear is available only for local access). Rotating
+a key invalidates clients that use the old one. Switching back to local keeps a
+key unless the operator separately confirms its removal.
 
-- An **API key is strongly recommended**. A **Require an API key** toggle
-  (on by default) makes the panel refuse to enable LAN access until you set
-  or generate one; the panel can generate a random key for you. If you
-  uncheck the toggle and leave the key blank, the router is served to your
-  network **unauthenticated** - anyone who can reach the port can use it.
-  When a key is set, clients must send `Authorization: Bearer <key>`.
-- `GET /models` (a metadata listing, no prompts or completions) is not
-  covered by the key - this is llama.cpp's own behavior, not
-  LlamaForge-specific. All inference endpoints (`/completion`,
-  `/v1/chat/completions`, etc.) are.
-- The setting is saved in `config.json` and re-applied on every restart
-  (including autostart), so it persists until you turn it back off.
-- Windows Firewall must allow inbound connections to `llama-server.exe` on
-  your network profile; if you're prompted by Windows the first time, allow
-  it for the profile you're actually on (Private/Public).
+Older printable keys may continue to protect an existing LAN configuration and
+are labelled `protected_legacy` with a rotation recommendation. Historical or
+manually edited unsupported hosts, and LAN configurations with an absent or
+invalid key, are assessed read-only as `unsafe_legacy`: LlamaForge does not
+silently rewrite them, but blocks any new start or restart until they are
+repaired. If a port is already occupied, the dashboard leaves its listener
+alone; seeing a listener is not verification of its process identity or of its
+authentication policy.
 
-The **LlamaForge dashboard itself** (port 8090) always stays local-only -
-it can trigger rebuilds, install prerequisites, and edit configuration, so
-it is intentionally not exposed by this feature. If you need to administer
-LlamaForge from another device, use remote desktop / SSH to this machine
-rather than exposing port 8090.
+## Management boundary and credentials
 
-## Threat model for the dashboard
+`/api/state`, `/api/config`, and routine management responses never include the
+router key. Their public config projection is an explicit allowlist plus the
+non-secret `router_api_key_configured` boolean. **Client Config**, **Show
+configuration** for an agent, and server-side **Generate** are deliberate,
+no-store reveal actions; they return credentials only to the initiating explicit
+POST where applicable. Every JSON response has `Cache-Control: no-store`.
 
-Binding to `127.0.0.1` keeps the dashboard off your network, but it does **not**
-put it out of reach: every web page you visit can send requests to
-`http://127.0.0.1:8090`. Since the dashboard's routes rebuild llama.cpp, install
-packages, run commands inside WSL and rewrite configuration, a page you merely
-*visit* must not be able to drive it.
+The panel treats every HTTP request as untrusted input:
 
-So the treated-as-untrusted input is **any HTTP request**, including one from
-your own browser, and the following rules apply:
+- Host and Origin checks keep requests tied to this loopback service and defend
+  against cross-site requests and DNS rebinding.
+- State-changing requests require JSON content type; this is defense in depth
+  against form posts.
+- POST framing requires one valid `Content-Length`; transfer encoding, malformed
+  or duplicate lengths, short bodies, and oversized requests are rejected and
+  the connection is closed. Management JSON is capped at 4 MiB; the
+  `/v1/messages` and `/v1/chat/completions` inference proxies have a 64 MiB cap
+  for realistic multimodal payloads.
+- `POST /api/config` accepts only a type-checked allowlist. Request data is not
+  interpolated into shell commands.
 
-- **Origin and Host are checked on every request.** A request whose `Origin`
-  names another site is refused (403), as is one whose `Host` is not this
-  loopback service - the latter blocks DNS rebinding, where an attacker's
-  hostname is re-pointed at `127.0.0.1` so their page counts as same-origin.
-- **State-changing requests must be `application/json`.** A cross-site
-  `<form>` can only send `text/plain`, `application/x-www-form-urlencoded` or
-  `multipart/form-data`; requiring JSON means a forged POST needs a CORS
-  preflight it cannot pass. Requests with a form content type get a 415.
-- **`POST /api/config` accepts an allowlist of keys**, each type-checked. Keys
-  naming a program or directory the backend reads (`server_bin`, `llama_src`,
-  `build_dir`, `models_ini`, `wiki_dir`, `docs_dir`) are *not* settable from the
-  browser - `server_bin` in particular is executed as `<server_bin> --help` to
-  build the knob schema. Those belong to `bootstrap` and `config.json`.
-- **Nothing from a request is interpolated into a shell command.** vLLM runs
-  through `bash -lc` inside WSL; model refs, HF repo ids and knob values are
-  bound as positional parameters (`"$1"`), and repo ids are additionally
-  validated against `org/name`. See the module docstring in `backend/wsl.py`.
+## Local limitations
 
-The router's API key is included in `/api/state` so the *Client config* panel can
-show a working `curl`. That is same-origin data on a loopback-only service; it is
-not a secret from the page that is already the dashboard.
+`config.json` stores `router_api_key` as plaintext; it is not encrypted and is
+not an OS credential vault. A process running under the same OS account may be
+able to read that file and inspect the llama-server command line, because the
+upstream process currently receives `--api-key` in argv. Explicit configuration
+previews improve resistance to accidental ambient disclosure, not isolation from
+such a local peer process.
 
 ## Reporting
 
-This is a personal/local tool, not a hosted service. If you find a security
-issue, please open an issue on the repo.
+This is an early-preview personal/local tool, not a hosted service or a security
+certification. If you find a security issue, please open an issue on the repo.

--- a/backend/clientsetup.py
+++ b/backend/clientsetup.py
@@ -1,0 +1,47 @@
+"""Generate deliberate OpenAI-compatible client snippets from a resolved target."""
+import json, shlex
+
+
+def _quote(value, shell):
+    if shell == "posix":
+        return shlex.quote(value)
+    if shell == "powershell":
+        return "'" + value.replace("'", "''") + "'"
+    raise ValueError("shell must be posix or powershell")
+
+
+def generate(endpoint, api_key, model, backend, shell):
+    base = endpoint.rstrip("/")
+    payload_obj = {
+        "model": model,
+        "messages": [{"role": "user", "content": "Hello"}],
+        "stream": False,
+    }
+    compact = json.dumps(payload_obj, separators=(",", ":"), ensure_ascii=False)
+    args = [
+        "curl", _quote(base + "/v1/chat/completions", shell),
+        "-H", _quote("Content-Type: application/json", shell),
+    ]
+    if api_key:
+        args += ["-H", _quote("Authorization: Bearer " + api_key, shell)]
+    args += ["-d", _quote(compact, shell)]
+    continuation = " `\n  " if shell == "powershell" else " "
+    curl = continuation.join(args)
+    shown_key = api_key or "not-required"
+    if shell == "powershell":
+        environment = (
+            "$env:OPENAI_BASE_URL = " + _quote(base + "/v1", shell) + "\n"
+            "$env:OPENAI_API_KEY = " + _quote(shown_key, shell) + "\n")
+    else:
+        environment = (
+            "export OPENAI_BASE_URL=" + _quote(base + "/v1", shell) + "\n"
+            "export OPENAI_API_KEY=" + _quote(shown_key, shell) + "\n")
+    environment += "# model id: " + json.dumps(model, ensure_ascii=True)
+    return {
+        "backend": backend,
+        "endpoint": base,
+        "auth_required": bool(api_key),
+        "curl": curl,
+        "environment": environment,
+        "payload": json.dumps(payload_obj, indent=2, ensure_ascii=False),
+    }

--- a/backend/clientsetup.py
+++ b/backend/clientsetup.py
@@ -25,7 +25,7 @@ def generate(endpoint, api_key, model, backend, shell):
     if api_key:
         args += ["-H", _quote("Authorization: Bearer " + api_key, shell)]
     args += ["-d", _quote(compact, shell)]
-    continuation = " `\n  " if shell == "powershell" else " "
+    continuation = " `\n  " if shell == "powershell" else " \\\n  "
     curl = continuation.join(args)
     shown_key = api_key or "not-required"
     if shell == "powershell":

--- a/backend/network_policy.py
+++ b/backend/network_policy.py
@@ -1,0 +1,180 @@
+"""Pure router network/key policy. No config or process side effects."""
+import argparse, copy, json, re, secrets, sys
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+
+STRONG_KEY_RE = re.compile(r"^[A-Za-z0-9._~-]{32,256}$")
+LEGACY_KEY_RE = re.compile(r"^[\x21-\x7E]{1,256}$")
+PUBLIC_CONFIG_KEYS = (
+    "theme", "cvd", "auto_load_model", "vram_bandwidths", "presets",
+    "preset_bindings", "active_engine",
+)
+
+
+@dataclass(frozen=True)
+class Assessment:
+    host: str
+    access_scope: str
+    configured_security_status: str
+    key_status: str
+    has_api_key: bool
+    remediation_required: bool
+    start_allowed: bool
+    message: str
+
+    def public(self):
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class NetworkMutation:
+    router_host: str
+    router_api_key: str
+    access_scope: str
+    key_action: str
+    assessment: Assessment
+    generated_api_key: str | None = None
+
+
+def key_status(value):
+    if value is None or value == "":
+        return "absent"
+    if not isinstance(value, str):
+        return "invalid"
+    if STRONG_KEY_RE.fullmatch(value):
+        return "strong"
+    if LEGACY_KEY_RE.fullmatch(value):
+        return "legacy"
+    return "invalid"
+
+
+def assess(host, key):
+    clean_host = host if isinstance(host, str) else ""
+    ks = key_status(key)
+    has_key = isinstance(key, str) and bool(key)
+    if clean_host == "127.0.0.1" and ks == "absent":
+        return Assessment(clean_host, "local", "local", ks, False,
+                          False, True, "")
+    if clean_host == "127.0.0.1" and ks in ("strong", "legacy"):
+        return Assessment(clean_host, "local", "local_keyed", ks, has_key,
+                          False, True, "")
+    if clean_host == "0.0.0.0" and ks in ("strong", "legacy"):
+        status = "protected" if ks == "strong" else "protected_legacy"
+        message = "" if ks == "strong" else "Rotate this legacy API key when convenient."
+        return Assessment(clean_host, "lan", status, ks, True,
+                          False, True, message)
+    message = ("LAN router start refused: select local access or configure a "
+               "usable API key before sharing the router.")
+    return Assessment(clean_host, "legacy", "unsafe_legacy", ks, has_key,
+                      True, False, message)
+
+
+def generate_key():
+    key = secrets.token_urlsafe(32)
+    if key_status(key) != "strong":
+        raise RuntimeError("generated API key did not satisfy policy")
+    return key
+
+
+def start_error(host, key):
+    result = assess(host, key)
+    return "" if result.start_allowed else result.message
+
+
+def _request_parts(body):
+    if not isinstance(body, Mapping):
+        raise ValueError("network request must be an object")
+    has_new = "access_scope" in body
+    has_old = "host" in body
+    if has_new == has_old:
+        raise ValueError("provide access_scope or the deprecated host shape, not both")
+    if has_new:
+        extra = set(body) - {"access_scope", "key_action", "api_key"}
+        if extra:
+            raise ValueError("unsupported network fields: " + ", ".join(sorted(extra)))
+        scope = body.get("access_scope")
+        action = body.get("key_action", "keep")
+        supplied = body.get("api_key") if "api_key" in body else None
+        supplied_present = "api_key" in body
+    else:
+        extra = set(body) - {"host", "api_key"}
+        if extra:
+            raise ValueError("unsupported network fields: " + ", ".join(sorted(extra)))
+        host = body.get("host")
+        if host not in ("127.0.0.1", "0.0.0.0"):
+            raise ValueError("host must be 127.0.0.1 or 0.0.0.0")
+        scope = "local" if host == "127.0.0.1" else "lan"
+        supplied_present = "api_key" in body
+        supplied = body.get("api_key") if supplied_present else None
+        action = "keep" if not supplied_present else ("clear" if supplied == "" else "replace")
+    return scope, action, supplied, supplied_present
+
+
+def apply_request(current, body):
+    scope, action, supplied, supplied_present = _request_parts(body)
+    if scope not in ("local", "lan"):
+        raise ValueError("access_scope must be local or lan")
+    if action not in ("keep", "generate", "replace", "clear"):
+        raise ValueError("key_action must be keep, generate, replace, or clear")
+    if action == "replace" and not supplied_present:
+        raise ValueError("api_key is required for replace")
+    if action != "replace" and supplied_present:
+        if not (action == "clear" and supplied == ""):
+            raise ValueError("api_key is valid only with key_action replace")
+
+    current_key = current.get("router_api_key", "") if isinstance(current, Mapping) else ""
+    generated = None
+    if action == "keep":
+        selected = current_key
+    elif action == "generate":
+        selected = generated = generate_key()
+    elif action == "replace":
+        if key_status(supplied) != "strong":
+            raise ValueError("replacement API key must be a strong 32-256 character URL-safe token")
+        selected = supplied
+    else:
+        if scope != "local":
+            raise ValueError("an API key can be cleared only for local access")
+        selected = ""
+
+    host = "127.0.0.1" if scope == "local" else "0.0.0.0"
+    result = assess(host, selected)
+    if not result.start_allowed:
+        raise ValueError(result.message)
+    return NetworkMutation(host, selected, scope, action, result, generated)
+
+
+def public_config(cfg):
+    out = {key: copy.deepcopy(cfg[key]) for key in PUBLIC_CONFIG_KEYS if key in cfg}
+    out["router_api_key_configured"] = bool(cfg.get("router_api_key"))
+    return out
+
+
+def preflight_config_file(path):
+    try:
+        with open(path, encoding="utf-8-sig") as f:
+            cfg = json.load(f)
+        if not isinstance(cfg, dict):
+            raise ValueError("config root must be an object")
+    except Exception as exc:
+        return False, "Router start refused: config could not be read (%s)." % exc
+    reason = start_error(cfg.get("router_host", "127.0.0.1"),
+                         cfg.get("router_api_key", ""))
+    return (not reason, reason)
+
+
+def main(argv: Sequence[str] | None = None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--preflight", metavar="CONFIG")
+    args = parser.parse_args(argv)
+    if not args.preflight:
+        parser.error("--preflight CONFIG is required")
+    ok, message = preflight_config_file(args.preflight)
+    if not ok:
+        print(message, file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/router_ctl.py
+++ b/backend/router_ctl.py
@@ -12,14 +12,19 @@ CREATE_NO_WINDOW = 0x08000000
 def lan_ip():
     """Best-effort local-network IP (no traffic sent; just picks the
     interface the OS would use to reach the internet)."""
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s = None
     try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         s.connect(("8.8.8.8", 80))
         return s.getsockname()[0]
     except Exception:
         return None
     finally:
-        s.close()
+        if s is not None:
+            try:
+                s.close()
+            except Exception:
+                pass
 
 # ---------------------------------------------------------------- capability
 # The router is driven as `<server_bin> --models-preset <ini> --models-max 1`.

--- a/backend/router_ctl.py
+++ b/backend/router_ctl.py
@@ -5,7 +5,7 @@ process bound to a port; Linux/macOS use lsof.
 """
 import os, signal, subprocess, time, socket
 
-import osplat
+import network_policy, osplat
 
 CREATE_NO_WINDOW = 0x08000000
 
@@ -96,6 +96,9 @@ def stop(port, timeout=10):
     return _pid_on_port(port) is None
 
 def start(server_bin, models_ini, port, host, api_key, logdir):
+    reason = network_policy.start_error(host, api_key)
+    if reason:
+        return False, reason
     if not server_bin or not os.path.exists(server_bin):
         return False, "server_bin not found - build llama.cpp first"
     # Port 8080 is a popular default (XAMPP, Apache, other dev servers). Without
@@ -127,5 +130,8 @@ def start(server_bin, models_ini, port, host, api_key, logdir):
     return True, ""
 
 def restart(server_bin, models_ini, port, host, api_key, logdir):
+    reason = network_policy.start_error(host, api_key)
+    if reason:
+        return False, reason
     stop(port)
     return start(server_bin, models_ini, port, host, api_key, logdir)

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -18,7 +18,7 @@ content_type. Raising ApiError(status, message) produces {"error": message}.
 Streaming responses (the Anthropic and OpenAI SSE proxies) are not in these
 tables: they write to the socket themselves and stay in server.py.
 """
-import json, os, subprocess, sys, urllib.request, urllib.error, urllib.parse
+import json, os, subprocess, sys, threading, urllib.request, urllib.error, urllib.parse
 
 import config, argspec, hardware, osplat, prereqs, scanner, hub, router_ctl, stats
 import autotune, anthropic_shim, agentsetup, clientsetup, network_policy, wiki, docs
@@ -87,6 +87,12 @@ _SCHEMA_KEY = None      # (server_bin, mtime) the cache was built from
 _IK_SCHEMA = None       # cached schema for ik_llama binary
 _IK_SCHEMA_KEY = None
 _VLLM_SCHEMA = None
+
+# Saving router-affecting config and restarting the process is one transaction.
+# ThreadingHTTPServer may run network and engine mutations concurrently; without
+# this boundary, the file and the live router can end up describing different
+# settings.  RLock keeps it safe for future lifecycle helpers to compose.
+_ROUTER_LIFECYCLE_LOCK = threading.RLock()
 
 
 def cfg():          return config.load()
@@ -1409,6 +1415,11 @@ def _network_error(error, secret):
 
 
 def post_network(req):
+    with _ROUTER_LIFECYCLE_LOCK:
+        return _post_network_locked(req)
+
+
+def _post_network_locked(req):
     current = cfg()
     try:
         mutation = network_policy.apply_request(current, req.body or {})
@@ -1446,6 +1457,11 @@ def post_network(req):
 
 
 def post_engine_switch(req):
+    with _ROUTER_LIFECYCLE_LOCK:
+        return _post_engine_switch_locked(req)
+
+
+def _post_engine_switch_locked(req):
     """Switch the active engine (llamacpp / ikllama) and restart the router.
 
     Validate the binary BEFORE persisting. `active_engine` steers ini_path(),

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -162,6 +162,15 @@ def _agent_endpoint(agent):
     return f"http://{host}:{c['router_port']}/v1"
 
 
+def _agent_endpoint_for(agent, inject, c=None):
+    c = c or cfg()
+    if agent == "claude-code":
+        return f"http://127.0.0.1:{c['panel_port']}"
+    if inject:
+        return f"http://127.0.0.1:{c['panel_port']}/v1"
+    return _llama_client_endpoint(c) + "/v1"
+
+
 _AGENT_CONTEXT_FILE = {"claude-code": ".claude/CLAUDE.md",
                        "codex": ".codex/AGENTS.md", "pi": ".pi/AGENTS.md"}
 
@@ -876,23 +885,72 @@ def post_client_config(req):
     return 200, out
 
 
-def get_agent_config(req):
-    agent = req.q("agent")
-    model = req.q("model")
-    small = req.q("small") or None
-    inject = req.flag("inject")
+def _resolve_agent_request(body):
+    allowed = {"agent", "model", "backend", "small", "inject"}
+    unknown = set(body) - allowed
+    if unknown:
+        raise ApiError(400, "unsupported agent-config fields: " + ", ".join(sorted(unknown)))
+    agent = body.get("agent", "")
+    if agent not in agentsetup.AGENTS:
+        raise ApiError(400, f"unknown agent: {agent}")
+    inject = body.get("inject")
+    if not isinstance(inject, bool):
+        raise ApiError(400, "inject must be a boolean")
+    if agent == "claude-code" and inject:
+        raise ApiError(400, "Claude Code always uses the local Anthropic endpoint")
+
+    backend = body.get("backend", "")
+    active = REGISTRY.active_engine()
+    if backend != active or backend not in backends.LLAMA_FAMILY:
+        raise ApiError(400, f"agent setup requires the active llama backend: {active}")
+    row, resolved_backend = _resolve_model_row(body.get("model"), backend)
+    if resolved_backend != active:
+        raise ApiError(400, f"model is not owned by active backend: {row['id']}")
+
+    small = body.get("small", "")
+    if not isinstance(small, str):
+        raise ApiError(400, "small must be a model id")
+    small = small or None
+    if small and agent != "claude-code":
+        raise ApiError(400, "small is only supported for Claude Code")
+    if small:
+        small_row, small_backend = _resolve_model_row(small, backend)
+        if small_backend != active:
+            raise ApiError(400, f"small model is not owned by active backend: {small_row['id']}")
+        small = small_row["id"]
+
     c = cfg()
-    if inject and agent in ("codex", "pi"):
-        host = router_ctl.lan_ip() if c.get("router_host", "127.0.0.1") != "127.0.0.1" else "127.0.0.1"
-        endpoint = f"http://{host}:{c['panel_port']}/v1"
-    else:
-        endpoint = _agent_endpoint(agent)
+    return {
+        "agent": agent,
+        "model": row["id"],
+        "backend": active,
+        "small": small,
+        "inject": inject,
+        "endpoint": _agent_endpoint_for(agent, inject, c),
+        "api_key": c.get("router_api_key", ""),
+    }
+
+
+def post_agent_config(req):
+    target = _resolve_agent_request(req.body or {})
     try:
-        out = agentsetup.generate(agent, endpoint, c.get("router_api_key", ""),
-                                  model, small, inject)
-    except ValueError as e:
-        raise ApiError(400, str(e))
+        out = agentsetup.generate(
+            target["agent"], target["endpoint"], target["api_key"],
+            target["model"], target["small"], target["inject"])
+    except Exception:
+        raise ApiError(500, "agent configuration could not be generated") from None
     return 200, out
+
+
+def get_agent_config(req):
+    """Remove with the old Setup consumer in Task 8."""
+    return post_agent_config(Req(body={
+        "agent": req.q("agent"),
+        "model": req.q("model"),
+        "backend": REGISTRY.active_engine(),
+        "small": req.q("small") or "",
+        "inject": req.flag("inject"),
+    }))
 
 
 def get_wiki_docs(req):
@@ -1476,16 +1534,23 @@ def post_count_tokens(req):
     return 200, {"input_tokens": anthropic_shim.count_tokens_estimate(req.body)}
 
 
+def _compat_agent_apply_body(body):
+    """Remove with the old Setup consumer in Task 8."""
+    if (isinstance(body, dict) and "backend" not in body and
+            "inject" not in body and
+            not (set(body) - {"agent", "model", "small"})):
+        return dict(body, backend=REGISTRY.active_engine(), inject=False)
+    return body
+
+
 def post_agent_apply(req):
-    agent = req.body.get("agent", "")
-    model = req.body.get("model", "")
-    small = req.body.get("small") or None
+    target = _resolve_agent_request(_compat_agent_apply_body(req.body or {}))
     try:
-        out = agentsetup.apply(agent, os.path.expanduser("~"),
-                               _agent_endpoint(agent),
-                               cfg().get("router_api_key", ""), model, small)
-    except ValueError as e:
-        raise ApiError(400, str(e))
+        out = agentsetup.apply(
+            target["agent"], os.path.expanduser("~"), target["endpoint"],
+            target["api_key"], target["model"], target["small"])
+    except Exception:
+        raise ApiError(500, "agent configuration could not be applied") from None
     return 200, out
 
 
@@ -1606,6 +1671,7 @@ POST_ROUTES = {
     "/api/vllm/hub/register":   post_vllm_hub_register,
     "/api/vllm/delete":         post_vllm_delete,
     "/v1/messages/count_tokens": post_count_tokens,
+    "/api/agent/config":        post_agent_config,
     "/api/agent/apply":         post_agent_apply,
     "/api/wiki/doc":            post_wiki_doc,
     "/api/wiki/doc/delete":     post_wiki_doc_delete,

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -687,10 +687,9 @@ def get_state(req):
 
 
 def _public_config(c):
-    """config.json as the dashboard sees it. The router API key is deliberately
-    included: the Client-config modal shows the exact curl the user needs, and
-    the panel is same-origin and localhost-only."""
-    return dict(c)
+    """Allowlisted browser state. Secret material is available only through
+    deliberate client/agent/network POST actions."""
+    return network_policy.public_config(c)
 
 
 def get_schema(req):
@@ -953,17 +952,6 @@ def post_agent_config(req):
     except Exception:
         raise ApiError(500, "agent configuration could not be generated") from None
     return 200, out
-
-
-def get_agent_config(req):
-    """Remove with the old Setup consumer in Task 8."""
-    return post_agent_config(Req(body={
-        "agent": req.q("agent"),
-        "model": req.q("model"),
-        "backend": REGISTRY.active_engine(),
-        "small": req.q("small") or "",
-        "inject": req.flag("inject"),
-    }))
 
 
 def get_wiki_docs(req):
@@ -1575,17 +1563,8 @@ def post_count_tokens(req):
     return 200, {"input_tokens": anthropic_shim.count_tokens_estimate(req.body)}
 
 
-def _compat_agent_apply_body(body):
-    """Remove with the old Setup consumer in Task 8."""
-    if (isinstance(body, dict) and "backend" not in body and
-            "inject" not in body and
-            not (set(body) - {"agent", "model", "small"})):
-        return dict(body, backend=REGISTRY.active_engine(), inject=False)
-    return body
-
-
 def post_agent_apply(req):
-    target = _resolve_agent_request(_compat_agent_apply_body(req.body))
+    target = _resolve_agent_request(req.body if req.body is not None else {})
     try:
         out = agentsetup.apply(
             target["agent"], os.path.expanduser("~"), target["endpoint"],
@@ -1657,7 +1636,6 @@ GET_ROUTES = {
     "/api/model/metadata":    get_model_metadata,
     "/api/model/diag":        get_model_diag,
     "/api/presets":           get_presets,
-    "/api/agent/config":      get_agent_config,
     "/api/wiki/docs":         get_wiki_docs,
     "/api/wiki/doc":          get_wiki_doc,
     "/api/wiki/profiles":     get_wiki_profiles,

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -759,15 +759,24 @@ def get_scan_missing(req):
     return 200, {"missing": missing}
 
 
-def get_network(req):
-    c = cfg()
-    return 200, {
-        "host": c.get("router_host", "127.0.0.1"),
+def _network_status(c, running=None):
+    assessment = network_policy.assess(
+        c.get("router_host", "127.0.0.1"),
+        c.get("router_api_key", ""))
+    if running is None:
+        running = router_ctl.is_running(c["router_port"])
+    out = assessment.public()
+    out.update({
         "port": c["router_port"],
-        "has_api_key": bool(c.get("router_api_key")),
         "lan_ip": router_ctl.lan_ip(),
-        "router_running": router_ctl.is_running(c["router_port"]),
-    }
+        "router_running": bool(running),
+        "listener_status": "listening" if running else "not_listening",
+    })
+    return out
+
+
+def get_network(req):
+    return 200, _network_status(cfg())
 
 
 def get_vllm_log(req):
@@ -1406,18 +1415,46 @@ def _record_server_bin(key, path):
     return True
 
 
+def _network_error(error, secret):
+    text = str(error or "")
+    return text.replace(secret, "[redacted]") if secret else text
+
+
 def post_network(req):
-    c = cfg()
-    host = req.body.get("host", "127.0.0.1")
-    api_key = req.body.get("api_key")
-    if api_key is None:
-        api_key = c.get("router_api_key", "")   # field left blank -> keep existing key
-    c = config.update({"router_host": host, "router_api_key": api_key})
-    sbin = _active_server_bin(c)
-    ini = config.ini_path()
-    ok, err = router_ctl.restart(sbin, ini, c["router_port"],
-                                 host, api_key, LOGDIR)
-    return (200 if ok else 500), {"ok": ok, "error": err, "host": host}
+    current = cfg()
+    try:
+        mutation = network_policy.apply_request(current, req.body or {})
+    except ValueError as e:
+        raise ApiError(400, str(e))
+    except Exception:
+        raise ApiError(500, "network change could not be prepared") from None
+
+    try:
+        c = config.update({
+            "router_host": mutation.router_host,
+            "router_api_key": mutation.router_api_key,
+        })
+    except Exception:
+        raise ApiError(500, "network settings could not be saved") from None
+    try:
+        ok, error = router_ctl.restart(
+            _active_server_bin(c), config.ini_path(), c["router_port"],
+            mutation.router_host, mutation.router_api_key, LOGDIR)
+    except Exception as exc:
+        ok, error = False, exc
+    running = router_ctl.is_running(c["router_port"])
+    out = _network_status(c, running)
+    out.update({
+        "ok": bool(ok),
+        "saved": True,
+        "restart_status": ("failed" if not ok else
+                           "running" if running else "starting"),
+    })
+    if error:
+        out["error"] = _network_error(error, mutation.router_api_key)
+    if mutation.generated_api_key is not None:
+        out["generated_api_key"] = mutation.generated_api_key
+    return (200 if ok else 500), out
 
 
 def post_engine_switch(req):

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -886,11 +886,15 @@ def post_client_config(req):
 
 
 def _resolve_agent_request(body):
+    if not isinstance(body, dict):
+        raise ApiError(400, "agent configuration must be an object")
     allowed = {"agent", "model", "backend", "small", "inject"}
     unknown = set(body) - allowed
     if unknown:
         raise ApiError(400, "unsupported agent-config fields: " + ", ".join(sorted(unknown)))
     agent = body.get("agent", "")
+    if not isinstance(agent, str):
+        raise ApiError(400, "agent must be a string")
     if agent not in agentsetup.AGENTS:
         raise ApiError(400, f"unknown agent: {agent}")
     inject = body.get("inject")
@@ -932,7 +936,7 @@ def _resolve_agent_request(body):
 
 
 def post_agent_config(req):
-    target = _resolve_agent_request(req.body or {})
+    target = _resolve_agent_request(req.body)
     try:
         out = agentsetup.generate(
             target["agent"], target["endpoint"], target["api_key"],
@@ -1544,7 +1548,7 @@ def _compat_agent_apply_body(body):
 
 
 def post_agent_apply(req):
-    target = _resolve_agent_request(_compat_agent_apply_body(req.body or {}))
+    target = _resolve_agent_request(_compat_agent_apply_body(req.body))
     try:
         out = agentsetup.apply(
             target["agent"], os.path.expanduser("~"), target["endpoint"],

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -21,7 +21,7 @@ tables: they write to the socket themselves and stay in server.py.
 import json, os, subprocess, sys, urllib.request, urllib.error, urllib.parse
 
 import config, argspec, hardware, osplat, prereqs, scanner, hub, router_ctl, stats
-import autotune, anthropic_shim, agentsetup, wiki, docs
+import autotune, anthropic_shim, agentsetup, clientsetup, network_policy, wiki, docs
 import vram_predict
 import wsl, vllm_ctl, vllm_registry, vllm_setup, vllm_job, vllm_hub, vllm_download
 import gguf, diag, backends
@@ -811,6 +811,71 @@ def get_presets(req):
     return 200, {"presets": config.get_presets()}
 
 
+def _resolve_model_row(mid, hint=""):
+    if not isinstance(mid, str) or not mid.strip():
+        raise ApiError(400, "model is required")
+    mid = mid.strip()
+    if not isinstance(hint, str):
+        raise ApiError(400, "backend must be a string")
+    if hint in backends.LLAMA_FAMILY:
+        hint = REGISTRY.active_engine()
+    elif hint and hint != "vllm":
+        raise ApiError(400, f"unknown backend: {hint}")
+
+    rows = [row for row in REGISTRY.state().get("models", [])
+            if row.get("id") == mid]
+    if hint:
+        rows = [row for row in rows if row.get("backend") == hint]
+    if not rows:
+        raise ApiError(400, f"unknown model/backend: {mid}/{hint or 'unspecified'}")
+    if len(rows) != 1:
+        raise ApiError(409, f"model ownership is ambiguous; supply backend for {mid}")
+    return rows[0], rows[0].get("backend", "")
+
+
+def _llama_client_endpoint(c):
+    assessment = network_policy.assess(
+        c.get("router_host", "127.0.0.1"), c.get("router_api_key", ""))
+    if assessment.access_scope == "local":
+        host = "127.0.0.1"
+    elif assessment.access_scope == "lan":
+        host = router_ctl.lan_ip()
+        if not host:
+            raise ApiError(503, "LAN IP is not available; use local-only or repair networking")
+    else:
+        raise ApiError(409, "repair the legacy Network Access configuration first")
+    return f"http://{host}:{c['router_port']}"
+
+
+def post_client_config(req):
+    body = req.body or {}
+    unknown = set(body) - {"model", "backend"}
+    if unknown:
+        raise ApiError(400, "unsupported client-config fields: " + ", ".join(sorted(unknown)))
+    row, backend = _resolve_model_row(body.get("model"), body.get("backend", ""))
+    c = cfg()
+    if backend in backends.LLAMA_FAMILY:
+        endpoint = _llama_client_endpoint(c)
+        api_key = c.get("router_api_key", "")
+    elif backend == "vllm":
+        live = next((item for item in vllm_mgr().status()
+                     if item.get("model_id") == row["id"]
+                     and item.get("state") == "ready"), None)
+        if not live or not live.get("endpoint"):
+            raise ApiError(400, f"vLLM model {row['id']} is not ready; load it first")
+        endpoint = live["endpoint"]
+        api_key = ""
+    else:
+        raise ApiError(400, f"unsupported backend: {backend}")
+    shell = "powershell" if osplat.IS_WIN else "posix"
+    try:
+        out = clientsetup.generate(endpoint, api_key, row["id"], backend, shell)
+    except Exception:
+        raise ApiError(500, "client configuration could not be generated") from None
+    out["model_loaded"] = row.get("status") == "loaded"
+    return 200, out
+
+
 def get_agent_config(req):
     agent = req.q("agent")
     model = req.q("model")
@@ -1496,6 +1561,7 @@ GET_ROUTES = {
 }
 
 POST_ROUTES = {
+    "/api/client/config":       post_client_config,
     # engine-agnostic (dispatch on the model's backend)
     "/api/models/load":         post_model_load,
     "/api/models/unload":       post_model_unload,

--- a/backend/server.py
+++ b/backend/server.py
@@ -37,6 +37,15 @@ from routes import ApiError, Req
 # application/json - requiring JSON on state-changing routes means an attacker's
 # page cannot forge one without a preflight it will fail.
 ALLOWED_HOSTS = {"127.0.0.1", "localhost", "[::1]", "::1"}
+MAX_MANAGEMENT_JSON_BODY_BYTES = 4 * 1024 * 1024
+MAX_PROXY_JSON_BODY_BYTES = 64 * 1024 * 1024
+_BODY_ERROR = object()
+
+
+def _post_body_limit(path):
+    if path in ("/v1/messages", "/v1/chat/completions"):
+        return MAX_PROXY_JSON_BODY_BYTES
+    return MAX_MANAGEMENT_JSON_BODY_BYTES
 
 
 def _host_ok(host_header, port):
@@ -83,6 +92,10 @@ class H(BaseHTTPRequestHandler):
         self.send_header("Content-Type", ctype)
         self.send_header("Content-Length", str(len(body)))
         self.send_header("X-Content-Type-Options", "nosniff")
+        if ctype.startswith("application/json"):
+            self.send_header("Cache-Control", "no-store")
+        if self.close_connection:
+            self.send_header("Connection", "close")
         self.end_headers()
         self.wfile.write(body)
 
@@ -96,15 +109,49 @@ class H(BaseHTTPRequestHandler):
     def _headers_lower(self):
         return {k.lower(): v for k, v in self.headers.items()}
 
+    def _body_error(self, code, message):
+        self.close_connection = True
+        self._send(code, {"error": message})
+        return _BODY_ERROR
+
+    def _read_json_body(self, path):
+        if self.headers.get("Transfer-Encoding") is not None:
+            return self._body_error(400, "Transfer-Encoding is not supported")
+        lengths = self.headers.get_all("Content-Length") or []
+        if not lengths:
+            return self._body_error(411, "Content-Length is required")
+        if len(lengths) != 1:
+            return self._body_error(400, "invalid Content-Length")
+        raw = lengths[0]
+        if not raw or not raw.isascii() or not raw.isdecimal():
+            return self._body_error(400, "invalid Content-Length")
+        size = int(raw)
+        if size > _post_body_limit(path):
+            return self._body_error(413, "request body too large")
+        data = self.rfile.read(size)
+        if len(data) != size:
+            return self._body_error(400, "incomplete request body")
+        try:
+            body = json.loads(data or b"{}")
+        except (UnicodeDecodeError, ValueError):
+            return self._body_error(400, "invalid JSON body")
+        if not isinstance(body, dict):
+            return self._body_error(400, "body must be a JSON object")
+        return body
+
     # ---------------------------------------------------------------- guards
     def _guard(self, method):
         """Reject anything that isn't this dashboard's own page talking to it.
         Returns True when the request has been answered and must not proceed."""
         port = routes.cfg()["panel_port"]
         if not _host_ok(self.headers.get("Host", ""), port):
+            if method == "POST":
+                self.close_connection = True
             self._send(403, {"error": "bad Host header"})
             return True
         if not _origin_ok(self.headers.get("Origin", ""), port):
+            if method == "POST":
+                self.close_connection = True
             self._send(403, {"error": "cross-origin request refused"})
             return True
         if method == "POST":
@@ -112,6 +159,7 @@ class H(BaseHTTPRequestHandler):
             # Requiring JSON means a forged post needs a preflight it can't pass.
             ctype = (self.headers.get("Content-Type") or "").split(";")[0].strip().lower()
             if ctype and ctype != "application/json":
+                self.close_connection = True
                 self._send(415, {"error": "Content-Type must be application/json"})
                 return True
         return False
@@ -167,14 +215,10 @@ class H(BaseHTTPRequestHandler):
     def do_POST(self):
         if self._guard("POST"):
             return
-        n = int(self.headers.get("Content-Length", 0) or 0)
-        try:
-            body = json.loads(self.rfile.read(n) or "{}") if n else {}
-        except ValueError:
-            return self._send(400, {"error": "invalid JSON body"})
-        if not isinstance(body, dict):
-            return self._send(400, {"error": "body must be a JSON object"})
         p = self.path.split("?")[0]
+        body = self._read_json_body(p)
+        if body is _BODY_ERROR:
+            return
         if self._vllm_gate(p):
             return
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -125,9 +125,13 @@ class H(BaseHTTPRequestHandler):
         raw = lengths[0]
         if not raw or not raw.isascii() or not raw.isdecimal():
             return self._body_error(400, "invalid Content-Length")
-        size = int(raw)
-        if size > _post_body_limit(path):
+        normalized = raw.lstrip("0") or "0"
+        limit = _post_body_limit(path)
+        limit_digits = str(limit)
+        if (len(normalized) > len(limit_digits) or
+                len(normalized) == len(limit_digits) and normalized > limit_digits):
             return self._body_error(413, "request body too large")
+        size = int(normalized)
         data = self.rfile.read(size)
         if len(data) != size:
             return self._body_error(400, "incomplete request body")

--- a/docs/content/agents.md
+++ b/docs/content/agents.md
@@ -15,28 +15,36 @@ LlamaForge exposes two HTTP surfaces a coding agent can talk to:
 - The **router** (`router_port`, default 8080) speaks the OpenAI `/v1/chat/completions` shape natively — this is what llama.cpp's router already serves.
 - The **Anthropic shim** (`backend/anthropic_shim.py`, served from the panel on `panel_port`, default 8090) translates Anthropic's `/v1/messages` Messages API into the router's OpenAI request shape and back, including streaming SSE and tool use, so an Anthropic-API client like Claude Code can drive a local model without knowing it isn't talking to Anthropic. `to_openai_request()` maps system/messages/tools/tool_choice/stop_sequences into the OpenAI body; `to_anthropic_response()` and `stream_anthropic_events()` map the router's response (or SSE chunk stream) back into Anthropic message/content-block events. `/v1/messages/count_tokens` is served too, but only as an estimate (`count_tokens_estimate()`: ~4 characters per token over the translated prompt text, not a real tokenizer count).
 
-Shim auth (`backend/server.py` `_shim_auth_ok()`) accepts either header an Anthropic client might send: `x-api-key: <key>` or `Authorization: Bearer <key>`. If the router is bound to `127.0.0.1` (the default), auth is skipped entirely; it's only enforced once `router_host` is changed to something reachable off the local machine, and only if a `router_api_key` is actually set — an empty key also skips the check.
+Shim auth (`backend/server.py` `_shim_auth_ok()`) accepts either header an Anthropic client might send: `x-api-key: <key>` or `Authorization: Bearer <key>`. The panel itself remains loopback-only. Network Access requires a usable router key for every newly configured LAN router; the shim forwards the configured credential to the router where needed.
 
 **Agent setup** (`backend/agentsetup.py`) generates the config each agent needs to point at LlamaForge, and can optionally write it in place:
 
 | Agent | Config file | Format | Endpoint it's given |
 |---|---|---|---|
-| `claude-code` | `~/.claude/settings.json` | JSON (`env` block) | The Anthropic shim, `http://127.0.0.1:<panel_port>` — always localhost, never the LAN, because the shim only binds locally. |
-| `codex` | `~/.codex/config.toml` | TOML (appended provider block) | The router's OpenAI-compatible endpoint, `http://<host>:<router_port>/v1` — `<host>` is the LAN IP when `router_host` is non-local, else `127.0.0.1`. |
-| `pi` | `~/.pi/agent/models.json` | JSON (`providers` block) | Same router endpoint rule as Codex. |
+| `claude-code` | `~/.claude/settings.json` | JSON (`env` block) | The loopback Anthropic endpoint, `http://127.0.0.1:<panel_port>` — always local, never the LAN. |
+| `codex` | `~/.codex/config.toml` | TOML (appended provider block) | Direct mode uses the router's OpenAI-compatible endpoint, `http://<host>:<router_port>/v1`; injected mode uses the loopback panel endpoint `http://127.0.0.1:<panel_port>/v1`. |
+| `pi` | `~/.pi/agent/models.json` | JSON (`providers` block) | The same direct-router or injected-loopback choice as Codex. |
 
 Claude Code's generated `settings.json` sets `ANTHROPIC_BASE_URL` to the shim endpoint, `ANTHROPIC_AUTH_TOKEN` to the router API key (or the literal string `llamaforge` if none is set — the shim needs a non-empty token even when auth is effectively open), `ANTHROPIC_MODEL`, and `ANTHROPIC_SMALL_FAST_MODEL`. Codex's TOML block declares a `[model_providers.llamaforge]` section with `wire_api = "chat"` and, if a router API key exists, an `env_key` pointing at a `LLAMAFORGE_API_KEY` environment variable the user must set — the key itself is never written to the TOML file. pi's `models.json` sets `api: "openai-completions"` with the key embedded directly in the config.
 
-Codex and pi can optionally be routed through the shim instead of the router directly by passing `inject=true` — this is how those two agents pick up wiki context injection (see [Context Wiki](context-wiki.md)), since only requests through the shim/proxy get the composed system-prompt merge.
+Codex and pi can optionally be routed through the loopback panel proxy with
+`inject=true` — this is how those two agents pick up wiki context injection (see
+[Context Wiki](context-wiki.md)). An injected endpoint is local-machine-only;
+direct Codex/pi configuration uses the router endpoint instead.
 
 Two apply paths exist: `generate()` returns the config content and a human-readable target path/instructions without touching disk (used for "copy this into your config" display); `apply()` actually writes it — JSON targets are deep-merged into any existing file (`_deep_merge()`, so unrelated existing keys survive), and the Codex TOML target is appended only if the `[model_providers.llamaforge]` block isn't already present, commenting out any conflicting top-level `model`/`model_provider` line rather than deleting it. Both paths back up the target file once, to `<path>.llamaforge.bak`, before the first write.
 
+The preview may deliberately contain the Claude Code or pi credential needed for
+that agent's native file. Treat it like Client Config: it is shown only after the
+explicit POST request. Apply may use the stored key to write a file, but its
+response never returns the key.
+
 ## How to use it
 
-1. Open the **Setup** tab and pick the agent you want to connect: Claude Code, Codex, or pi.dev.
-2. Choose the model (and, for Claude Code, an optional small/fast model) it should use.
-3. Preview the generated config and endpoint. For Codex or pi.dev, optionally enable context injection to route through the shim instead of the router directly.
-4. Click **Apply** to write the config into the agent's real config file on this machine, or copy the generated snippet and merge it yourself.
+1. Open the **Setup** tab and pick Claude Code, Codex, or pi.dev.
+2. Choose a model from the active llama-family engine (and, for Claude Code, an optional small/fast model). vLLM agent setup is deferred.
+3. Press **Show configuration**. This is the only preview action: it is an explicit POST and is not fetched on render or selection change. For Codex or pi.dev, choose injection only when the agent runs on this same machine.
+4. Review or copy the preview, then click **Apply** only to write the config into the agent's real local config file.
 5. Launch the agent. Claude Code must run on the same machine as LlamaForge — its endpoint is always `127.0.0.1`.
 
 ## Reference
@@ -47,9 +55,9 @@ Two apply paths exist: `generate()` returns the config content and a human-reada
 | Anthropic response translation | `backend/anthropic_shim.py` `to_anthropic_response()` / `stream_anthropic_events()` | OpenAI response/SSE -> Anthropic message / streaming content-block events. |
 | Token estimate | `backend/anthropic_shim.py` `count_tokens_estimate()` | Advisory only: `len(text) // 4` over the translated prompt. |
 | Shim auth | `backend/server.py` `_shim_auth_ok()` | Accepts `x-api-key` or `Authorization: Bearer <key>`; skipped when `router_host` is `127.0.0.1` or no `router_api_key` is set. |
-| Endpoint per agent | `backend/server.py` `_agent_endpoint()` | Claude Code -> shim at `127.0.0.1:panel_port`; Codex/pi -> router at `<host>:router_port/v1`. |
-| Config generation | `backend/agentsetup.py` `generate()` | Pure: returns `{agent, format, target_path, content, endpoint, instructions}` without writing. |
-| Config apply | `backend/agentsetup.py` `apply()` | Writes to the real target path; JSON deep-merged, Codex TOML appended if absent; backs up the original once. |
+| Endpoint per agent | `backend/routes.py` `_agent_endpoint_for()` | Claude Code -> loopback Anthropic endpoint; direct Codex/pi -> router at `<host>:router_port/v1`; injected Codex/pi -> loopback panel at `127.0.0.1:panel_port/v1`. |
+| Config preview | `POST /api/agent/config` | Explicit POST with `{agent, model, backend, small, inject}`; may deliberately contain Claude/pi credentials and does not write files. |
+| Config apply | `POST /api/agent/apply` | Same targeting fields; writes to the real target path, JSON is deep-merged and Codex TOML appended if absent, original is backed up once. Apply never returns a key. |
 
 ## Troubleshooting
 

--- a/docs/content/agents.md
+++ b/docs/content/agents.md
@@ -32,7 +32,7 @@ Codex and pi can optionally be routed through the loopback panel proxy with
 [Context Wiki](context-wiki.md)). An injected endpoint is local-machine-only;
 direct Codex/pi configuration uses the router endpoint instead.
 
-Two apply paths exist: `generate()` returns the config content and a human-readable target path/instructions without touching disk (used for "copy this into your config" display); `apply()` actually writes it — JSON targets are deep-merged into any existing file (`_deep_merge()`, so unrelated existing keys survive), and the Codex TOML target is appended only if the `[model_providers.llamaforge]` block isn't already present, commenting out any conflicting top-level `model`/`model_provider` line rather than deleting it. Both paths back up the target file once, to `<path>.llamaforge.bak`, before the first write.
+Preview generation returns config content and a human-readable target path/instructions without touching disk (used for "copy this into your config" display). Apply writes it — JSON targets are deep-merged into any existing file (`_deep_merge()`, so unrelated existing keys survive), and the Codex TOML target is appended only if the `[model_providers.llamaforge]` block isn't already present, commenting out any conflicting top-level `model`/`model_provider` line rather than deleting it. Apply backs up the target once, to `<path>.llamaforge.bak`, before its first write.
 
 The preview may deliberately contain the Claude Code or pi credential needed for
 that agent's native file. Treat it like Client Config: it is shown only after the

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -8,7 +8,8 @@ order: 3
 
 The LlamaForge dashboard backend (`backend/server.py`) listens on `panel_port` (default `8090`) and serves the web UI, the `/api/*` management API, and two agent-facing, provider-compatible chat endpoints. All routes below are read directly from `do_GET`/`do_POST` in `backend/server.py`.
 
-`/api/*` request/response bodies are JSON. POST handlers read the body with `json.loads(self.rfile.read(n) or "{}")`, so a POST with no body is treated as `{}`.
+`/api/*` request/response bodies are JSON. Every JSON response has
+`Cache-Control: no-store`.
 
 > [!NOTE]
 > If vLLM support isn't available on the host, every route is first checked by `_vllm_gate()`; requests to `/api/vllm/*` paths return an error response instead of reaching the normal handler.
@@ -30,7 +31,7 @@ These are the endpoints external coding agents (Claude Code, Codex, etc.) talk t
 
 | Method | Path | Purpose |
 |---|---|---|
-| GET | `/api/state` | Full dashboard state: models (llama.cpp + vLLM merged), GPU telemetry, platform, current `config.json`, and onboarding status. |
+| GET | `/api/state` | Dashboard state: models (llama.cpp + vLLM merged), GPU telemetry, platform, public config projection, and onboarding status. `config` is an exact allowlist (`theme`, `cvd`, `auto_load_model`, `vram_bandwidths`, `presets`, `preset_bindings`, `active_engine`) plus `router_api_key_configured`; it is not full `config.json` and never includes the key. |
 | GET | `/api/schema` | The knob schema (available `llama-server` flags), built from `llama-server --help`. |
 | POST | `/api/save` | Save per-model knob overrides into `models.ini` (`config.set_keys`). Reloads the running model if it was loaded. |
 | GET | `/api/presets` | List saved knob presets from `config.json`. |
@@ -80,8 +81,9 @@ These are the endpoints external coding agents (Claude Code, Codex, etc.) talk t
 
 | Method | Path | Purpose |
 |---|---|---|
-| GET | `/api/network` | Current router host/port, whether an API key is set, LAN IP, and whether the router is running. |
-| POST | `/api/network` | Update `router_host`/`router_api_key` in `config.json` and restart the router (`router_ctl.restart`). |
+| GET | `/api/network` | Redacted Network Access status: canonical/legacy access scope, configured host and security/key status, key-present boolean, remediation message, configured port and LAN IP, plus `router_running`/`listener_status`. A listening port is observation only, not process-identity or authentication verification. |
+| POST | `/api/network` | Save a canonical Network Access request and restart the router. Body: `{access_scope: "local"|"lan", key_action: "keep"|"generate"|"replace"|"clear", api_key?: "..."}`. `replace` requires a strong replacement; `clear` is local-only; LAN has no unauthenticated path. For one release, the old `{host, api_key}` shape is accepted only for canonical hosts. A generated key is returned only as `generated_api_key` to that explicit request. Results distinguish saved configuration from `restart_status` (`running`, `starting`, or `failed`) and listener observation. |
+| POST | `/api/client/config` | Deliberately generate client snippets for `{model, backend}`. llama-family output may contain the router key; active vLLM output does not. Unknown, ambiguous, or unloaded vLLM targets are rejected. |
 | GET | `/api/router/log` | Tail of the router's log. |
 | GET | `/api/stats` | Usage stats summary. |
 | POST | `/api/stats/reset` | Reset usage stats. |
@@ -115,8 +117,8 @@ Only reachable when vLLM support is available on the host (`_vllm_gate`).
 
 | Method | Path | Purpose |
 |---|---|---|
-| GET | `/api/agent/config` | Generate connection config (endpoint, key, model) for a named coding agent (query params `agent`, `model`, `small`, `inject`). |
-| POST | `/api/agent/apply` | Write the generated agent config to disk on the machine running the dashboard. |
+| POST | `/api/agent/config` | Deliberately preview connection config for `{agent, model, backend, small, inject}`. It is POST-only; the active llama-family backend is required and vLLM is rejected. |
+| POST | `/api/agent/apply` | Write agent config on the dashboard machine using the same targeting fields (`agent`, `model`, `backend`, `small`, `inject`). It may use the stored key internally but never returns a key. |
 | GET | `/api/wiki/docs` | List context-wiki documents. |
 | GET | `/api/wiki/doc` | Read a single document (query param `name`). |
 | POST | `/api/wiki/doc` | Create/update a document. |
@@ -168,6 +170,12 @@ reachable by any page in your browser. Every request is therefore checked:
   DNS rebinding.
 - `POST` bodies must be `application/json`. A form content type gets **415**,
   which is what stops a cross-site `<form>` from forging a state change.
+- Every POST requires exactly one ASCII-decimal `Content-Length`. Missing length
+  is **411**. Malformed, duplicate, or transfer-encoded framing is **400**; a
+  short body is also **400**. Rejected framing closes the connection.
+- Management POSTs are limited to 4 MiB. `/v1/messages` and
+  `/v1/chat/completions` use a 64 MiB inference-proxy limit. A body over its
+  route-class limit is **413** before it is read or dispatched.
 - `POST /api/config` only accepts an allowlist of user-facing keys. See
   [Security](https://github.com/dadwritestech/LlamaForge/blob/master/SECURITY.md).
 

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -20,9 +20,9 @@ These are the endpoints external coding agents (Claude Code, Codex, etc.) talk t
 
 | Method | Path | Purpose |
 |---|---|---|
-| POST | `/v1/messages` | Anthropic Messages API-compatible endpoint. Requires `x-api-key` auth (`_shim_auth_ok`) and `anthropic_shim_enabled: true` in `config.json` (the default). Supports `"stream": true` (SSE) via `_anthropic_stream`. Internally translated to the OpenAI-shaped request and forwarded to the router (`_anthropic_messages` -> `_router_openai`). |
-| POST | `/v1/messages/count_tokens` | Anthropic-compatible token-count estimate for a would-be `/v1/messages` request. Same auth/enable gating as `/v1/messages`. |
-| POST | `/v1/chat/completions` | OpenAI Chat Completions-compatible endpoint. Requires auth via `_shim_auth_ok`. Injects the active wiki context profile as a system message (`_inject_openai_system`) before forwarding to the router. Supports `"stream": true`. |
+| POST | `/v1/messages` | Anthropic Messages API-compatible endpoint. Requires `anthropic_shim_enabled: true` in `config.json` (the default) and uses conditional `_shim_auth_ok`: auth is skipped for local router scope (and current behavior also skips when no key is configured); when enforced, it accepts either `x-api-key` or `Authorization: Bearer <key>`. Supports `"stream": true` (SSE) via `_anthropic_stream`, translates to the OpenAI-shaped request, and forwards to the router. |
+| POST | `/v1/messages/count_tokens` | Anthropic-compatible token-count estimate for a would-be `/v1/messages` request. Same enable and conditional auth behavior as `/v1/messages`. |
+| POST | `/v1/chat/completions` | OpenAI Chat Completions-compatible endpoint with the same conditional `_shim_auth_ok` behavior. Injects the active wiki context profile as a system message (`_inject_openai_system`) before forwarding to the router. Supports `"stream": true`. |
 | POST | `/api/load` | Load a model into the router. Body: `{"model": "<id>"}`. Proxies to the router's `/models/load`. |
 | POST | `/api/unload` | Unload a model from the router. Body: `{"model": "<id>"}`. Proxies to the router's `/models/unload`. |
 | POST | `/api/unload_all` | Unload every currently loaded/loading model (except the router's `default` entry). |
@@ -168,8 +168,9 @@ reachable by any page in your browser. Every request is therefore checked:
 - `Host` must name this loopback service, and `Origin` — when present — must
   match it. Anything else gets **403**. This blocks both cross-site requests and
   DNS rebinding.
-- `POST` bodies must be `application/json`. A form content type gets **415**,
-  which is what stops a cross-site `<form>` from forging a state change.
+- When a POST declares `Content-Type`, it must be `application/json`; declared
+  form or other non-JSON content types get **415**, helping block a cross-site
+  `<form>`. This guard currently permits an absent `Content-Type`.
 - Every POST requires exactly one ASCII-decimal `Content-Length`. Missing length
   is **411**. Malformed, duplicate, or transfer-encoded framing is **400**; a
   short body is also **400**. Rejected framing closes the connection.

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -19,8 +19,8 @@ order: 1
 | `model_dirs` | list | `[]` | Directories the Discover/scan feature searches for GGUF files. |
 | `router_port` | int | `8080` | Port `llama-server` (the router) listens on. |
 | `panel_port` | int | `8090` | Port the LlamaForge dashboard (`backend/server.py`) listens on. |
-| `router_host` | string | `"127.0.0.1"` | Router bind address. `127.0.0.1` = local only; `0.0.0.0` = reachable on the LAN. |
-| `router_api_key` | string | `""` | API key required from clients when `router_host` is not `127.0.0.1`. |
+| `router_host` | string | `"127.0.0.1"` | Router bind address. The Network Access UI supports only `127.0.0.1` (local) and `0.0.0.0` (LAN). |
+| `router_api_key` | string | `""` | Plaintext API key required for LAN. It is not returned in ordinary dashboard state. |
 | `wsl_distro` | string | `""` | WSL distro that runs vLLM. Empty string auto-picks the default distro. |
 | `vllm_port` | int | `8081` | Port vLLM serves on inside WSL (localhost-forwarded to Windows). |
 | `cmake_flags` | object | `{}` | Persisted CMake build flags, normally seeded from hardware detection. |
@@ -68,3 +68,17 @@ maps are migrated to the engine that was active when they were saved.
 `config.migrate()` runs once at server startup (`backend/server.py` `main()`) to classify pre-existing installs: a config file with no `ui_mode` key is treated as a legacy install. If `server_bin` is already set, it is stamped `ui_mode: "advanced"` and `onboarded: True`; otherwise it gets `ui_mode: "lite"` and `onboarded: False`, so the onboarding wizard shows. The migration is idempotent — a config that already has `ui_mode` is returned unchanged.
 
 See also [models.ini Format](models-ini.md) for the preset file `models_ini` points at, and [HTTP API](api.md) for the endpoints that read and write these keys.
+
+## Network Access and historical configuration
+
+`POST /api/network` is the supported way to change the router scope and key. It
+uses explicit `keep`, `generate`, `replace`, and local-only `clear` actions;
+newly configured LAN access requires a usable key and LlamaForge-owned starts
+fail closed without one. `config.json` is a normal plaintext file, not an OS
+credential vault.
+
+LlamaForge assesses existing values read-only. A printable older LAN key can
+remain in use as `protected_legacy` and is marked for rotation. A manually edited
+unsupported host, or LAN with an absent or invalid key, remains visible as
+`unsafe_legacy`; it is not auto-rewritten, but future starts and restarts are
+blocked until you generate/replace a key or return the router to local access.

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -28,7 +28,11 @@ LlamaForge is a llama.cpp control panel first, but it can also drive [vLLM](http
 
 ## Is my API key or model traffic sent anywhere?
 
-By default everything binds to `127.0.0.1` only. The **Setup** tab has a Network Access panel to opt into serving the llama.cpp API/chat UI to other devices on your network, and a **Require an API key** toggle (on by default) that blocks LAN access until you set or generate a key. See [SECURITY.md](https://github.com/dadwritestech/LlamaForge/blob/master/SECURITY.md) in the repository.
+The dashboard and its management API always bind to `127.0.0.1`. The separate
+llama.cpp router is local by default; the Setup tab can make that router LAN
+accessible at `0.0.0.0`, but a usable API key is backend-enforced for every new
+LAN configuration and LlamaForge-owned start. There is no unauthenticated-LAN
+toggle. See [SECURITY.md](https://github.com/dadwritestech/LlamaForge/blob/master/SECURITY.md) in the repository.
 
 ## Where do I go if something breaks?
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -28,7 +28,7 @@ LlamaForge runs two local HTTP services:
 | Dashboard (panel) | `http://127.0.0.1:8090` | The LlamaForge backend and web UI — Models, Stats, Discover, Build, Setup tabs. Always binds to `127.0.0.1` only. |
 | Router | `http://127.0.0.1:8080` | llama.cpp's own server process, started by LlamaForge with `--models-preset models.ini`. Serves the OpenAI-compatible API and llama.cpp's chat UI. |
 
-Both ports, along with the bind address, are configured by the `panel_port`, `router_port`, and `router_host` keys in `config.json` (defaults `8090`, `8080`, and `127.0.0.1`). The router's bind address can be widened to `0.0.0.0` from the Setup tab's Network Access panel to reach it from other devices on your LAN; the dashboard itself never leaves `127.0.0.1`.
+Both ports, along with the bind address, are configured by the `panel_port`, `router_port`, and `router_host` keys in `config.json` (defaults `8090`, `8080`, and `127.0.0.1`). The Setup tab's Network Access panel supports only local `127.0.0.1` and LAN `0.0.0.0` router scopes. LAN requires a usable API key and LlamaForge-owned starts fail closed until it is configured; the dashboard itself never leaves `127.0.0.1`.
 
 Clients — `curl`, an OpenAI SDK, or any OpenAI-compatible chat client — talk to the router, not the dashboard. The dashboard's job is configuration: it writes model presets into `models.ini`, starts and stops the router, and reads back the router's own metrics endpoint for the Stats tab.
 

--- a/docs/content/setup.md
+++ b/docs/content/setup.md
@@ -48,10 +48,13 @@ the router's `127.0.0.1` scope or **Devices on my local network** for its
 
 Choose one unambiguous key action: **Keep current key**, **Generate / rotate**,
 **Replace**, or **Remove**. Remove is available only with local access; moving
-from LAN back to local otherwise retains the key. Rotation warns before it
-persists because clients using the previous key will stop authenticating. A
-generated key is returned only by that explicit Generate action: it starts masked,
-can be copied without displaying plaintext, and its optional reveal is temporary.
+from LAN back to local otherwise retains the key. Generating or replacing over an
+existing key, and removing an existing key, each require confirmation. Rotation
+warns because clients using the previous key will stop authenticating. A generated
+key is returned only by that explicit Generate action: it starts masked, can be
+copied without displaying plaintext, and its one-time reveal expires after 30
+seconds. Retry, Done, navigation, or a Setup rerender clears the value and its
+copy closure.
 
 Older printable LAN keys are retained as `protected_legacy` so an upgrade does
 not force an immediate client outage, but the card recommends rotation. Unsupported

--- a/docs/content/setup.md
+++ b/docs/content/setup.md
@@ -39,6 +39,42 @@ The tab also surfaces `hardware.recommend()`'s detected CPU/GPU (shared with the
 5. Click **Check for deleted models** to find registry entries whose backing file no longer exists on disk, then prune the ones you confirm.
 6. Optionally pick a model under **Startup** to auto-load when LlamaForge launches.
 
+## Network Access
+
+The Network Access card controls the llama.cpp router, never the dashboard: the
+panel and management API stay on `127.0.0.1`. Choose **This computer only** for
+the router's `127.0.0.1` scope or **Devices on my local network** for its
+`0.0.0.0` scope. LAN selection requires a usable key before Apply is enabled.
+
+Choose one unambiguous key action: **Keep current key**, **Generate / rotate**,
+**Replace**, or **Remove**. Remove is available only with local access; moving
+from LAN back to local otherwise retains the key. Rotation warns before it
+persists because clients using the previous key will stop authenticating. A
+generated key is returned only by that explicit Generate action: it starts masked,
+can be copied without displaying plaintext, and its optional reveal is temporary.
+
+Older printable LAN keys are retained as `protected_legacy` so an upgrade does
+not force an immediate client outage, but the card recommends rotation. Unsupported
+manual hosts and LAN configurations with an absent or invalid key are displayed as
+`unsafe_legacy`, not silently rewritten. Repair them by generating/replacing the
+key or returning to local-only; new router starts and restarts remain blocked until
+then.
+
+Applying saves a validated safe configuration and requests a restart. The status
+separates saved settings from observed listener state: a port being occupied does
+not prove that it belongs to LlamaForge or enforces the expected key. If restart
+fails, the saved protected configuration remains, but the router is stopped or
+unverified rather than claimed as active: “A protected configuration was saved,
+but the router is stopped; LAN protection is not currently active or verified.”
+
+## Connect an Agent
+
+Changing an agent or model selection does not fetch credentials. Press **Show
+configuration** to make the explicit POST preview, then choose **Apply** only if
+you want LlamaForge to write the agent's local config file. Agent setup supports
+the active llama-family backend; vLLM agent setup is deferred. Context injection
+for Codex and pi uses the loopback panel endpoint, so it is local-machine-only.
+
 ## Screenshot
 
 ![Setup tab](docs/img/setup.png)
@@ -60,5 +96,11 @@ The tab also surfaces `hardware.recommend()`'s detected CPU/GPU (shared with the
 ## Troubleshooting
 
 If **Install** doesn't appear for a missing tool, no supported package manager was found for your OS (Windows without winget or choco, macOS without Homebrew) — use the tool's download URL shown next to it instead. If a Windows install reports "winget failed" then falls through to choco, check the combined output shown in the toast/log for the underlying error (often a source-agreement prompt or an already-installed conflicting version). If the drive scan finds nothing on Windows, confirm your models sit on a fixed (non-removable, non-network) drive — `list_drives()` skips those by design. If **Check for deleted models** reports an entry you know still exists, verify the `model` path in `models.ini` matches the file's real location; a moved file reads as "deleted" until you re-scan and re-apply it.
+
+If Network Access says settings were saved but router start is not verified,
+read the displayed start error and router log, then use Retry after fixing it.
+The port check only observes a listener; it cannot prove listener ownership or
+authentication. An `unsafe_legacy` warning means LlamaForge deliberately refused
+to start/restart until the configured host and key are repaired.
 
 See also [Build & Update](build.md) for the same hardware detection used to pick CMake flags, and [vLLM Backend](vllm.md) for the WSL2 install flow shown at the bottom of this tab on Windows.

--- a/docs/content/stats.md
+++ b/docs/content/stats.md
@@ -28,7 +28,7 @@ Each model's record in `stats.json` (`{"models": {...}, "daily": {...}, "first_s
 3. **Activity** is a stacked prompt/generated bar chart; toggle **14d** / **30d** to change the window.
 4. **Per-model Usage** lists every model with logged usage — total tokens, average tok/s while generating, run count, time loaded, and when it was last used. Click a column chip to sort by it.
 5. Click **Reset stats** to zero the whole store (`POST /api/stats/reset`) — this is destructive and cannot be undone.
-6. To share the router on your LAN: go to **Setup** → **Network Access**, select local-network access, then explicitly generate or replace a key before **Apply & Restart Router**. The dashboard remains loopback-only.
+6. To share the router on your LAN: go to **Setup** → **Network Access**, select local-network access, then keep a usable existing key or explicitly generate or replace one before **Apply & Restart Router**. The dashboard remains loopback-only.
 
 ## Screenshot
 

--- a/docs/content/stats.md
+++ b/docs/content/stats.md
@@ -6,11 +6,11 @@ order: 5
 
 # Usage Stats
 
-Per-model token counts, run counts, and generation speed, a daily activity chart, and the LAN-sharing / API-key toggle for the router.
+Per-model token counts, run counts, and generation speed, with a daily activity chart.
 
 ## What it does
 
-The dashboard itself never sees inference traffic — clients talk to the llama.cpp router directly — and llama.cpp's own Prometheus counters reset on every router restart and keep no per-model history. `backend/stats.py`'s `StatsTracker` works around both limits with a background poller (`run_forever()`, every `POLL_SECS = 5` seconds) that:
+The dashboard itself never sees inference traffic — clients talk to the llama.cpp router directly — so it cannot provide per-client or per-IP accounting. It records per-model aggregates only. llama.cpp's own Prometheus counters reset on every router restart and keep no per-model history. `backend/stats.py`'s `StatsTracker` works around both limits with a background poller (`run_forever()`, every `POLL_SECS = 5` seconds) that:
 
 1. Calls the router's `/models` endpoint to learn whether it's up and which model is currently loaded (`--models-max 1`, so at most one model is ever loaded at a time — this is what makes attributing token deltas to "the loaded model" safe).
 2. Scrapes `/metrics?model=<id>` for that model's cumulative `llamacpp:prompt_tokens_total` and `llamacpp:tokens_predicted_total` counters, diffs them against the previous poll, and adds the delta to that model's running totals — only when the *same* model stayed loaded across both polls, and only when the delta is non-negative (a drop means the router restarted and the counters reset, so it's treated as zero rather than subtracted).
@@ -19,7 +19,7 @@ The dashboard itself never sees inference traffic — clients talk to the llama.
 
 Each model's record in `stats.json` (`{"models": {...}, "daily": {...}, "first_seen": ...}`) tracks `prompt`, `generated`, `loaded_secs`, `gen_secs`, `runs`, and `last_used`. A "run" increments whenever generation transitions from idle to active (`_idle` flag), which approximates a request count without the router exposing one directly. Average tokens/sec (`avg_tps`) is `generated / gen_secs`, where `gen_secs` only accumulates during poll windows that had active generation — so it reflects throughput while generating, not wall-clock time the model was loaded. Daily totals are kept for `DAILY_KEEP = 30` days and trimmed on each write.
 
-**LAN sharing and the API key.** The router binds to `127.0.0.1` (local only) by default. The **Network Access** panel — part of the Setup tab's UI, backed by `GET/POST /api/network` — lets you rebind it to `0.0.0.0` so other devices on your network can reach it at `http://<lan-ip>:<port>/`, where the LAN IP comes from `router_ctl.lan_ip()`. Enforcement is real, not merely a UI toggle: `router_ctl.start()` passes `--api-key <key>` straight to the `llama-server` process whenever a key is configured, so llama.cpp itself rejects unauthenticated requests once LAN access is on and a key is set. With LAN access on and no key set, the router is reachable by anyone on the network unauthenticated — the UI warns about this and defaults the "require an API key" checkbox to checked. The dashboard's own proxied calls (e.g. the OpenAI-compatible shim in `backend/anthropic_shim.py`) send the configured key as `Authorization: Bearer <key>` automatically; external clients must do the same. `GET /api/network` reports `has_api_key` (a boolean, never the key itself) so the UI can show "(unchanged — a key is already set)" without ever re-displaying a saved key.
+**LAN sharing and the API key.** The router binds to `127.0.0.1` (local only) by default. The **Network Access** panel — backed by `GET/POST /api/network` — can set its canonical LAN scope (`0.0.0.0`) so other devices can reach `http://<lan-ip>:<port>/`. Every newly configured LAN router requires a usable key and LlamaForge-owned starts fail closed without one; `router_ctl.start()` passes the selected key to llama-server as `--api-key`. The dashboard's own proxy calls send the configured key as `Authorization: Bearer <key>` when applicable, and external clients must use the current key. Ordinary state is redacted: Client/Agent previews and generated-key responses are deliberate, no-store exceptions rather than ambient key visibility.
 
 ## How to use it
 
@@ -28,7 +28,7 @@ Each model's record in `stats.json` (`{"models": {...}, "daily": {...}, "first_s
 3. **Activity** is a stacked prompt/generated bar chart; toggle **14d** / **30d** to change the window.
 4. **Per-model Usage** lists every model with logged usage — total tokens, average tok/s while generating, run count, time loaded, and when it was last used. Click a column chip to sort by it.
 5. Click **Reset stats** to zero the whole store (`POST /api/stats/reset`) — this is destructive and cannot be undone.
-6. To share the router on your LAN: go to the **Setup** tab's **Network Access** panel, check "allow access from other devices on my network," optionally click **Generate Key** (or type your own), then **Apply & Restart Router**.
+6. To share the router on your LAN: go to **Setup** → **Network Access**, select local-network access, then explicitly generate or replace a key before **Apply & Restart Router**. The dashboard remains loopback-only.
 
 ## Screenshot
 
@@ -46,11 +46,11 @@ Each model's record in `stats.json` (`{"models": {...}, "daily": {...}, "first_s
 | Daily retention | `stats.py: DAILY_KEEP` | 30 days of daily buckets kept; UI toggles between showing the last 14 or 30. |
 | Persistence | `stats.py: STATS_FILE` | `stats.json` at the repo root; atomic write via temp file + `os.replace`. |
 | LAN bind | `POST /api/network` | Sets `router_host` to `0.0.0.0` (LAN) or `127.0.0.1` (local only) and restarts the router. |
-| API key enforcement | `router_ctl.start()` | Passed to `llama-server` as `--api-key <key>`; llama.cpp enforces it, not the dashboard. |
-| Key visibility | `GET /api/network` | Returns `has_api_key: bool` only — the stored key itself is never sent back to the browser. |
+| API key enforcement | `router_ctl.start()` | LlamaForge refuses an unsafe LAN start and passes a configured usable key to `llama-server` as `--api-key <key>`. |
+| Key visibility | Ordinary state / explicit actions | `/api/state` and `/api/network` are redacted. Deliberate Client Config, Agent Config, and Generate actions are the no-store credential-bearing exceptions. |
 
 ## Troubleshooting
 
-If "Live Throughput" shows the router offline but models load fine, confirm the router process is actually running on `router_port` — `has_api_key`/`router_running` come from `GET /api/network`, and the poller re-baselines (`self._prev = None`) whenever `/models` fails to answer. If per-model totals look stuck at zero for a model you know ran, check that it wasn't reloaded mid-generation: a token delta is only counted when the same model ID was loaded on the previous poll, so a reload during a burst discards that window. If external clients get `401`/`403` after enabling LAN access, verify they're sending `Authorization: Bearer <key>` with the exact key generated in the Network Access panel — a blank key field on save keeps the previously stored key rather than clearing it.
+If "Live Throughput" shows the router offline but models load fine, confirm the router process is actually running on `router_port` — `router_running` comes from `GET /api/network`, and the poller re-baselines (`self._prev = None`) whenever `/models` fails to answer. If per-model totals look stuck at zero for a model you know ran, check that it wasn't reloaded mid-generation: a token delta is only counted when the same model ID was loaded on the previous poll, so a reload during a burst discards that window. If external clients get `401`/`403` after enabling LAN access, verify they're sending `Authorization: Bearer <key>` with the current key from the deliberate configuration/generation action.
 
 See also [Setup](setup.md) for the Network Access panel this page's LAN/API-key section documents, and [Models & Tuning](models.md) for per-model configuration.

--- a/docs/content/whats-new.md
+++ b/docs/content/whats-new.md
@@ -8,6 +8,20 @@ order: 1
 
 This page summarizes the most recent additions to LlamaForge. Each entry links to the full reference for that capability. For the longer-term direction, see the project's `ROADMAP.md`.
 
+## Fail-closed network and explicit credentials
+
+Network Access now distinguishes the loopback-only dashboard from the router it
+controls. LlamaForge accepts only local (`127.0.0.1`) or LAN (`0.0.0.0`) router
+scope, requires a usable key for every newly configured LAN router, and refuses
+LlamaForge-owned starts/restarts when that policy is unsafe. Existing manual or
+legacy settings are shown for repair rather than silently rewritten. Routine
+dashboard state is redacted; Client Config, Agent Config, and generated keys are
+deliberate no-store actions. This is tested product behavior in an early preview,
+not a formal security standard or audit certification.
+
+See [Security](https://github.com/dadwritestech/LlamaForge/blob/master/SECURITY.md),
+[Setup](setup.md), [HTTP API](api.md), and [Connect an Agent](agents.md).
+
 ## ik_llama as a second llama-family engine
 
 The Build tab now builds and drives **ik_llama.cpp** alongside stock llama.cpp, switched with one control (`POST /api/engine/switch`). The switch is gated on a capability probe: a binary whose `llama-server` lacks router mode (`--models-preset`) is refused with an explanation rather than taking the router down, and ik_llama keeps its own `models.ini` registry (a `-ikllama` sibling of the main one). Per-model tuning comes along automatically because the knob schema is parsed from whichever binary is active.

--- a/run.ps1
+++ b/run.ps1
@@ -21,6 +21,34 @@ if (-not (Test-Path $cfgPath)) {
 }
 $cfg = Get-Content $cfgPath -Raw | ConvertFrom-Json
 
+function Test-LlamaForgePython($Candidate) {
+  try {
+    $probeArgs = @(
+      "-c", "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)")
+    & $Candidate @probeArgs *> $null
+    return $LASTEXITCODE -eq 0
+  } catch {
+    return $false
+  }
+}
+
+function Resolve-LlamaForgePython {
+  $py = Get-Command py -CommandType Application -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+  if ($py -and (Test-LlamaForgePython $py.Source)) {
+    return [PSCustomObject]@{ File = $py.Source }
+  }
+  $python = Get-Command python -CommandType Application -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+  if ($python -and (Test-LlamaForgePython $python.Source)) {
+    return [PSCustomObject]@{ File = $python.Source }
+  }
+  throw "A working Python 3.10+ interpreter is required (tried 'py' and 'python')."
+}
+
+$LfPython = Resolve-LlamaForgePython
+$pythonFile = $LfPython.File
+
 function Listening($port){ [bool](Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue) }
 
 $logDir = Join-Path $here "logs"
@@ -28,54 +56,63 @@ New-Item -ItemType Directory -Force -Path $logDir | Out-Null
 
 # 1. llama.cpp / ik_llama router (only if not already up)
 if (-not (Listening $cfg.router_port)) {
-  # Choose binary based on active_engine setting
-  $engine = if ($cfg.active_engine) { $cfg.active_engine } else { "llamacpp" }
-  if ($engine -eq "ikllama") {
-    $serverBin = $cfg.ik_llama_server_bin
-    $engineLabel = "ik_llama"
-    # Mirror config.ini_path(): derive a sibling of models_ini, splitting on the
-    # extension. .Replace(".ini", ...) is a global replace and would also rewrite
-    # any parent directory whose name contains ".ini".
-    $modelsIni = if ($cfg.ik_llama_models_ini) { $cfg.ik_llama_models_ini } else {
-      Join-Path ([IO.Path]::GetDirectoryName($cfg.models_ini)) `
-                ([IO.Path]::GetFileNameWithoutExtension($cfg.models_ini) + "-ikllama" +
-                 [IO.Path]::GetExtension($cfg.models_ini))
+  $preflightArgs = @(
+    (Join-Path $here "backend\network_policy.py"), "--preflight", $cfgPath)
+  & $pythonFile @preflightArgs
+  $routerSafe = $LASTEXITCODE -eq 0
+  if (-not $routerSafe) {
+    Write-Host "Router not started: repair Network Access in the dashboard." -ForegroundColor Yellow
+  }
+  if ($routerSafe) {
+    # Choose binary based on active_engine setting
+    $engine = if ($cfg.active_engine) { $cfg.active_engine } else { "llamacpp" }
+    if ($engine -eq "ikllama") {
+      $serverBin = $cfg.ik_llama_server_bin
+      $engineLabel = "ik_llama"
+      # Mirror config.ini_path(): derive a sibling of models_ini, splitting on the
+      # extension. .Replace(".ini", ...) is a global replace and would also rewrite
+      # any parent directory whose name contains ".ini".
+      $modelsIni = if ($cfg.ik_llama_models_ini) { $cfg.ik_llama_models_ini } else {
+        Join-Path ([IO.Path]::GetDirectoryName($cfg.models_ini)) `
+                  ([IO.Path]::GetFileNameWithoutExtension($cfg.models_ini) + "-ikllama" +
+                   [IO.Path]::GetExtension($cfg.models_ini))
+      }
+    } else {
+      $serverBin = $cfg.server_bin
+      $engineLabel = "llama.cpp"
+      $modelsIni = $cfg.models_ini
     }
-  } else {
-    $serverBin = $cfg.server_bin
-    $engineLabel = "llama.cpp"
-    $modelsIni = $cfg.models_ini
-  }
-  # Mirror config._abs(): the router is started without -WorkingDirectory, and
-  # config.example.json ships "./models.ini", so a relative value resolved
-  # against whatever directory the user ran this from - the router then read an
-  # empty registry and loaded 0 models.
-  if ($modelsIni -and -not [IO.Path]::IsPathRooted($modelsIni)) {
-    $modelsIni = [IO.Path]::GetFullPath((Join-Path $here $modelsIni))
-  }
-  # Mirror config.ensure_models_ini(): llama-server refuses to start without
-  # this file, and the router is launched here, before the backend can make one.
-  if ($modelsIni -and -not (Test-Path $modelsIni)) {
-    Set-Content -Path $modelsIni -Encoding utf8 -Value @(
-      "; LlamaForge model registry - read by llama-server's router.",
-      "; Sections are model ids; keys are llama-server flags.",
-      "version = 1",
-      "",
-      "[*]",
-      "ctx-size = 150000")
-    Write-Host "created $modelsIni"
-  }
-  if (Test-Path $serverBin) {
-    $routerHost = if ($cfg.router_host) { $cfg.router_host } else { "127.0.0.1" }
-    $args = @("--models-preset", $modelsIni, "--models-max", "1", "--offline",
-              "--host", $routerHost, "--port", "$($cfg.router_port)", "--metrics")
-    if ($cfg.router_api_key) { $args += @("--api-key", $cfg.router_api_key) }
-    Start-Process -FilePath $serverBin -ArgumentList $args -WindowStyle Hidden `
-                  -RedirectStandardOutput (Join-Path $logDir "router.out.log") `
-                  -RedirectStandardError  (Join-Path $logDir "router.err.log")
-    Write-Host "started $engineLabel router on $($routerHost):$($cfg.router_port)"
-  } else {
-    Write-Host "server_bin not found ($serverBin) - open the dashboard Build tab to build $engineLabel first." -ForegroundColor Yellow
+    # Mirror config._abs(): the router is started without -WorkingDirectory, and
+    # config.example.json ships "./models.ini", so a relative value resolved
+    # against whatever directory the user ran this from - the router then read an
+    # empty registry and loaded 0 models.
+    if ($modelsIni -and -not [IO.Path]::IsPathRooted($modelsIni)) {
+      $modelsIni = [IO.Path]::GetFullPath((Join-Path $here $modelsIni))
+    }
+    # Mirror config.ensure_models_ini(): llama-server refuses to start without
+    # this file, and the router is launched here, before the backend can make one.
+    if ($modelsIni -and -not (Test-Path $modelsIni)) {
+      Set-Content -Path $modelsIni -Encoding utf8 -Value @(
+        "; LlamaForge model registry - read by llama-server's router.",
+        "; Sections are model ids; keys are llama-server flags.",
+        "version = 1",
+        "",
+        "[*]",
+        "ctx-size = 150000")
+      Write-Host "created $modelsIni"
+    }
+    if (Test-Path $serverBin) {
+      $routerHost = if ($cfg.router_host) { $cfg.router_host } else { "127.0.0.1" }
+      $args = @("--models-preset", $modelsIni, "--models-max", "1", "--offline",
+                "--host", $routerHost, "--port", "$($cfg.router_port)", "--metrics")
+      if ($cfg.router_api_key) { $args += @("--api-key", $cfg.router_api_key) }
+      Start-Process -FilePath $serverBin -ArgumentList $args -WindowStyle Hidden `
+                    -RedirectStandardOutput (Join-Path $logDir "router.out.log") `
+                    -RedirectStandardError  (Join-Path $logDir "router.err.log")
+      Write-Host "started $engineLabel router on $($routerHost):$($cfg.router_port)"
+    } else {
+      Write-Host "server_bin not found ($serverBin) - open the dashboard Build tab to build $engineLabel first." -ForegroundColor Yellow
+    }
   }
 } else {
   # Something already holds the router port. If it isn't a llama-server, the
@@ -92,11 +129,14 @@ if (-not (Listening $cfg.router_port)) {
 
 # 2. LlamaForge backend (dashboard)
 if (-not (Listening $cfg.panel_port)) {
-  Start-Process -FilePath "python" -ArgumentList (Join-Path $here "backend\server.py") `
+  $panelArgs = @((Join-Path $here "backend\server.py"))
+  Start-Process -FilePath $pythonFile -ArgumentList $panelArgs `
                 -WorkingDirectory (Join-Path $here "backend") -WindowStyle Hidden
   Write-Host "started LlamaForge dashboard on port $($cfg.panel_port)"
 }
 
 # 3. open the dashboard
-Start-Sleep -Seconds 2
-Start-Process "http://127.0.0.1:$($cfg.panel_port)/"
+if (-not $env:LLAMAFORGE_NO_BROWSER) {
+  Start-Sleep -Seconds 2
+  Start-Process "http://127.0.0.1:$($cfg.panel_port)/"
+}

--- a/run.sh
+++ b/run.sh
@@ -60,15 +60,19 @@ fi
 
 # 1. llama.cpp router (only if not already up)
 if ! listening "$router_port"; then
-  if [ -x "$server_bin" ]; then
-    args=(--models-preset "$models_ini" --models-max 1 --offline
-          --host "$router_host" --port "$router_port" --metrics)
-    [ -n "$api_key" ] && args+=(--api-key "$api_key")
-    nohup "$server_bin" "${args[@]}" \
-      >>"$logdir/router.out.log" 2>>"$logdir/router.err.log" </dev/null &
-    echo "started llama.cpp router on $router_host:$router_port"
+  if python3 "$here/backend/network_policy.py" --preflight "$cfg"; then
+    if [ -x "$server_bin" ]; then
+      args=(--models-preset "$models_ini" --models-max 1 --offline
+            --host "$router_host" --port "$router_port" --metrics)
+      [ -n "$api_key" ] && args+=(--api-key "$api_key")
+      nohup "$server_bin" "${args[@]}" \
+        >>"$logdir/router.out.log" 2>>"$logdir/router.err.log" </dev/null &
+      echo "started llama.cpp router on $router_host:$router_port"
+    else
+      echo "server_bin not found ($server_bin) - open the dashboard Build tab to build llama.cpp first."
+    fi
   else
-    echo "server_bin not found ($server_bin) - open the dashboard Build tab to build llama.cpp first."
+    echo "Router not started: repair Network Access in the dashboard." >&2
   fi
 else
   # Something already holds the router port. If it isn't a llama-server, the
@@ -90,6 +94,12 @@ if ! listening "$panel_port"; then
 fi
 
 # 3. open the dashboard
-sleep 2
-url="http://127.0.0.1:$panel_port/"
-if [ "$(uname)" = "Darwin" ]; then open "$url"; else xdg-open "$url" >/dev/null 2>&1 || echo "open $url"; fi
+if [ -z "${LLAMAFORGE_NO_BROWSER:-}" ]; then
+  sleep 2
+  url="http://127.0.0.1:$panel_port/"
+  if [ "$(uname)" = "Darwin" ]; then
+    open "$url"
+  else
+    xdg-open "$url" >/dev/null 2>&1 || echo "open $url"
+  fi
+fi

--- a/tests/test_agent_config_routes.py
+++ b/tests/test_agent_config_routes.py
@@ -48,13 +48,20 @@ class AgentEndpointMatrixTest(unittest.TestCase):
                     "http://127.0.0.1:8090/v1",
                 )
 
-    def test_direct_agent_uses_lan_router_not_lan_panel(self):
+    def test_direct_codex_and_pi_use_the_resolved_router_v1(self):
         lan = dict(CFG, router_host="0.0.0.0")
         with mock.patch.object(routes.router_ctl, "lan_ip", return_value="192.168.1.8"):
-            self.assertEqual(
-                routes._agent_endpoint_for("pi", False, lan),
-                "http://192.168.1.8:8080/v1",
-            )
+            for agent in ("codex", "pi"):
+                with self.subTest(agent=agent, scope="local"):
+                    self.assertEqual(
+                        routes._agent_endpoint_for(agent, False, CFG),
+                        "http://127.0.0.1:8080/v1",
+                    )
+                with self.subTest(agent=agent, scope="lan"):
+                    self.assertEqual(
+                        routes._agent_endpoint_for(agent, False, lan),
+                        "http://192.168.1.8:8080/v1",
+                    )
 
 
 class AgentConfigRouteTest(unittest.TestCase):
@@ -63,6 +70,25 @@ class AgentConfigRouteTest(unittest.TestCase):
             mock.patch.object(routes, "REGISTRY", FakeRegistry(rows, active)),
             mock.patch.object(routes, "cfg", return_value=cfg),
         )
+
+    def _assert_rejected_by_both(self, body, rows=LLAMA_ROWS, active="llamacpp",
+                                 message=None):
+        for handler in (routes.post_agent_config, routes.post_agent_apply):
+            patches = self._patch(rows=rows, active=active)
+            req = Req()
+            req.body = body
+            with self.subTest(handler=handler.__name__), patches[0], patches[1], \
+                 mock.patch.object(routes.agentsetup, "generate") as generate, \
+                 mock.patch.object(routes.agentsetup, "apply") as apply, \
+                 mock.patch.object(routes.os.path, "expanduser") as expanduser, \
+                 self.assertRaises(ApiError) as cm:
+                handler(req)
+            self.assertEqual(cm.exception.status, 400)
+            if message:
+                self.assertEqual(cm.exception.message, message)
+            generate.assert_not_called()
+            apply.assert_not_called()
+            expanduser.assert_not_called()
 
     def test_preview_and_apply_use_the_same_resolved_endpoint(self):
         body = {"agent": "pi", "model": "main", "backend": "llamacpp",
@@ -96,56 +122,47 @@ class AgentConfigRouteTest(unittest.TestCase):
             routes.post_agent_config(Req(body=body))
         self.assertEqual(generate.call_args.args[4], "small")
 
-    def test_vllm_unknown_and_stale_backends_are_rejected(self):
-        vrows = [{"id": "v", "backend": "vllm", "status": "loaded"}]
-        bodies = [
-            {"agent": "pi", "model": "v", "backend": "vllm",
-             "small": "", "inject": False},
-            {"agent": "pi", "model": "main", "backend": "unknown",
-             "small": "", "inject": False},
-            {"agent": "pi", "model": "main", "backend": "ikllama",
-             "small": "", "inject": False},
-        ]
-        for body in bodies:
-            rows = vrows if body["backend"] == "vllm" else LLAMA_ROWS
-            patches = self._patch(rows=rows)
-            with self.subTest(body=body), patches[0], patches[1], \
-                 self.assertRaises(ApiError) as cm:
-                routes.post_agent_config(Req(body=body))
-            self.assertEqual(cm.exception.status, 400)
+    def test_malformed_body_and_agent_are_rejected(self):
+        self._assert_rejected_by_both([[]])
+        self._assert_rejected_by_both({
+            "agent": [], "model": "main", "backend": "llamacpp",
+            "small": "", "inject": False,
+        })
 
-    def test_bad_inject_or_extra_fields_fail_before_generate_or_write(self):
-        bad = [
-            {"agent": "pi", "model": "main", "backend": "llamacpp",
-             "small": "", "inject": "true"},
-            {"agent": "claude-code", "model": "main", "backend": "llamacpp",
-             "small": "", "inject": True},
-            {"agent": "pi", "model": "main", "backend": "llamacpp",
-             "small": "", "inject": False, "endpoint": "http://evil"},
-            {"agent": "claude-code", "model": "main", "backend": "llamacpp",
-             "small": [], "inject": False},
+    def test_rejection_matrix_validates_before_dependencies(self):
+        cases = [
+            ("empty array", [], LLAMA_ROWS, "llamacpp"),
+            ("extra field", {"agent": "pi", "model": "main", "backend": "llamacpp",
+                             "small": "", "inject": False, "endpoint": "http://evil"},
+             LLAMA_ROWS, "llamacpp"),
+            ("bad inject", {"agent": "pi", "model": "main", "backend": "llamacpp",
+                            "small": "", "inject": "true"}, LLAMA_ROWS, "llamacpp"),
+            ("claude inject", {"agent": "claude-code", "model": "main",
+                               "backend": "llamacpp", "small": "", "inject": True},
+             LLAMA_ROWS, "llamacpp"),
+            ("malformed small", {"agent": "claude-code", "model": "main",
+                                 "backend": "llamacpp", "small": [], "inject": False},
+             LLAMA_ROWS, "llamacpp"),
+            ("contradictory ownership", {"agent": "pi", "model": "main",
+                                         "backend": "llamacpp", "small": "", "inject": False},
+             [{"id": "main", "backend": "ikllama", "status": "loaded"}], "llamacpp"),
+            ("active vllm", {"agent": "pi", "model": "v", "backend": "vllm",
+                             "small": "", "inject": False},
+             [{"id": "v", "backend": "vllm", "status": "loaded"}], "vllm"),
+            ("non-claude small", {"agent": "pi", "model": "main", "backend": "llamacpp",
+                                  "small": "small", "inject": False}, LLAMA_ROWS, "llamacpp"),
+            ("unknown backend", {"agent": "pi", "model": "main", "backend": "unknown",
+                                 "small": "", "inject": False}, LLAMA_ROWS, "llamacpp"),
+            ("stale backend", {"agent": "pi", "model": "main", "backend": "ikllama",
+                               "small": "", "inject": False}, LLAMA_ROWS, "llamacpp"),
+            ("missing model", {"agent": "pi", "model": "missing", "backend": "llamacpp",
+                              "small": "", "inject": False}, LLAMA_ROWS, "llamacpp"),
         ]
-        for body in bad:
-            patches = self._patch()
-            with self.subTest(body=body), patches[0], patches[1], \
-                 mock.patch.object(routes.agentsetup, "generate") as generate, \
-                 mock.patch.object(routes.agentsetup, "apply") as apply, \
-                 self.assertRaises(ApiError):
-                routes.post_agent_config(Req(body=body))
-            generate.assert_not_called()
-            apply.assert_not_called()
-
-    def test_apply_validates_before_touching_home(self):
-        body = {"agent": "pi", "model": "missing", "backend": "llamacpp",
-                "small": "", "inject": False}
-        patches = self._patch()
-        with patches[0], patches[1], \
-             mock.patch.object(routes.os.path, "expanduser") as expanduser, \
-             mock.patch.object(routes.agentsetup, "apply") as apply, \
-             self.assertRaises(ApiError):
-            routes.post_agent_apply(Req(body=body))
-        expanduser.assert_not_called()
-        apply.assert_not_called()
+        for name, body, rows, active in cases:
+            with self.subTest(case=name):
+                self._assert_rejected_by_both(
+                    body, rows, active,
+                    "agent configuration must be an object" if name == "empty array" else None)
 
     def test_temporary_apply_adapter_preserves_the_current_frontend_shape(self):
         old_body = {"agent": "pi", "model": "main", "small": ""}

--- a/tests/test_agent_config_routes.py
+++ b/tests/test_agent_config_routes.py
@@ -164,17 +164,13 @@ class AgentConfigRouteTest(unittest.TestCase):
                     body, rows, active,
                     "agent configuration must be an object" if name == "empty array" else None)
 
-    def test_temporary_apply_adapter_preserves_the_current_frontend_shape(self):
-        old_body = {"agent": "pi", "model": "main", "small": ""}
+    def test_legacy_apply_shape_is_removed_after_frontend_cutover(self):
         patches = self._patch()
-        with patches[0], patches[1], \
-             mock.patch.object(
-                 routes.agentsetup, "apply",
-                 return_value={"ok": True, "path": "p", "backup": None,
-                               "action": "created"}) as apply:
-            status, _ = routes.post_agent_apply(Req(body=old_body))
-        self.assertEqual(status, 200)
-        self.assertEqual(apply.call_args.args[2], "http://127.0.0.1:8080/v1")
+        with patches[0], patches[1], self.assertRaises(ApiError) as cm:
+            routes.post_agent_apply(Req(body={
+                "agent": "pi", "model": "main", "small": ""}))
+        self.assertEqual(cm.exception.status, 400)
+        self.assertIn("inject", str(cm.exception))
 
     def test_preview_and_apply_failures_never_echo_the_router_key(self):
         body = {"agent": "pi", "model": "main", "backend": "llamacpp",

--- a/tests/test_agent_config_routes.py
+++ b/tests/test_agent_config_routes.py
@@ -1,0 +1,184 @@
+import conftest_paths  # noqa: F401
+import json
+import unittest
+from unittest import mock
+
+import routes
+from routes import ApiError, Req
+
+
+SECRET = "agent-secret-" + "z" * 32
+CFG = {
+    "active_engine": "llamacpp",
+    "router_host": "127.0.0.1",
+    "router_port": 8080,
+    "panel_port": 8090,
+    "router_api_key": SECRET,
+}
+LLAMA_ROWS = [
+    {"id": "main", "backend": "llamacpp", "status": "loaded"},
+    {"id": "small", "backend": "llamacpp", "status": "unloaded"},
+]
+
+
+class FakeRegistry:
+    def __init__(self, rows=LLAMA_ROWS, active="llamacpp"):
+        self.rows = rows
+        self.active = active
+
+    def state(self):
+        return {"models": [dict(row) for row in self.rows], "global": {}}
+
+    def active_engine(self):
+        return self.active
+
+
+class AgentEndpointMatrixTest(unittest.TestCase):
+    def test_claude_is_always_panel_loopback(self):
+        self.assertEqual(
+            routes._agent_endpoint_for("claude-code", False, CFG),
+            "http://127.0.0.1:8090",
+        )
+
+    def test_codex_and_pi_injected_are_panel_loopback_v1(self):
+        for agent in ("codex", "pi"):
+            with self.subTest(agent=agent):
+                self.assertEqual(
+                    routes._agent_endpoint_for(agent, True, CFG),
+                    "http://127.0.0.1:8090/v1",
+                )
+
+    def test_direct_agent_uses_lan_router_not_lan_panel(self):
+        lan = dict(CFG, router_host="0.0.0.0")
+        with mock.patch.object(routes.router_ctl, "lan_ip", return_value="192.168.1.8"):
+            self.assertEqual(
+                routes._agent_endpoint_for("pi", False, lan),
+                "http://192.168.1.8:8080/v1",
+            )
+
+
+class AgentConfigRouteTest(unittest.TestCase):
+    def _patch(self, rows=LLAMA_ROWS, cfg=CFG, active="llamacpp"):
+        return (
+            mock.patch.object(routes, "REGISTRY", FakeRegistry(rows, active)),
+            mock.patch.object(routes, "cfg", return_value=cfg),
+        )
+
+    def test_preview_and_apply_use_the_same_resolved_endpoint(self):
+        body = {"agent": "pi", "model": "main", "backend": "llamacpp",
+                "small": "", "inject": True}
+        patches = self._patch()
+        with patches[0], patches[1], \
+             mock.patch.object(routes.agentsetup, "generate",
+                               return_value={"content": SECRET, "endpoint": "x"}) as generate:
+            status, preview = routes.post_agent_config(Req(body=body))
+        self.assertEqual(status, 200)
+        self.assertEqual(generate.call_args.args[1], "http://127.0.0.1:8090/v1")
+        self.assertIn(SECRET, json.dumps(preview))
+
+        patches = self._patch()
+        with patches[0], patches[1], \
+             mock.patch.object(routes.agentsetup, "apply",
+                               return_value={"ok": True, "path": "p",
+                                             "backup": None, "action": "created"}) as apply:
+            status, written = routes.post_agent_apply(Req(body=body))
+        self.assertEqual(status, 200)
+        self.assertEqual(apply.call_args.args[2], "http://127.0.0.1:8090/v1")
+        self.assertNotIn(SECRET, json.dumps(written))
+
+    def test_claude_small_model_is_validated_on_same_backend(self):
+        body = {"agent": "claude-code", "model": "main", "backend": "llamacpp",
+                "small": "small", "inject": False}
+        patches = self._patch()
+        with patches[0], patches[1], \
+             mock.patch.object(routes.agentsetup, "generate",
+                               return_value={"content": "ok"}) as generate:
+            routes.post_agent_config(Req(body=body))
+        self.assertEqual(generate.call_args.args[4], "small")
+
+    def test_vllm_unknown_and_stale_backends_are_rejected(self):
+        vrows = [{"id": "v", "backend": "vllm", "status": "loaded"}]
+        bodies = [
+            {"agent": "pi", "model": "v", "backend": "vllm",
+             "small": "", "inject": False},
+            {"agent": "pi", "model": "main", "backend": "unknown",
+             "small": "", "inject": False},
+            {"agent": "pi", "model": "main", "backend": "ikllama",
+             "small": "", "inject": False},
+        ]
+        for body in bodies:
+            rows = vrows if body["backend"] == "vllm" else LLAMA_ROWS
+            patches = self._patch(rows=rows)
+            with self.subTest(body=body), patches[0], patches[1], \
+                 self.assertRaises(ApiError) as cm:
+                routes.post_agent_config(Req(body=body))
+            self.assertEqual(cm.exception.status, 400)
+
+    def test_bad_inject_or_extra_fields_fail_before_generate_or_write(self):
+        bad = [
+            {"agent": "pi", "model": "main", "backend": "llamacpp",
+             "small": "", "inject": "true"},
+            {"agent": "claude-code", "model": "main", "backend": "llamacpp",
+             "small": "", "inject": True},
+            {"agent": "pi", "model": "main", "backend": "llamacpp",
+             "small": "", "inject": False, "endpoint": "http://evil"},
+            {"agent": "claude-code", "model": "main", "backend": "llamacpp",
+             "small": [], "inject": False},
+        ]
+        for body in bad:
+            patches = self._patch()
+            with self.subTest(body=body), patches[0], patches[1], \
+                 mock.patch.object(routes.agentsetup, "generate") as generate, \
+                 mock.patch.object(routes.agentsetup, "apply") as apply, \
+                 self.assertRaises(ApiError):
+                routes.post_agent_config(Req(body=body))
+            generate.assert_not_called()
+            apply.assert_not_called()
+
+    def test_apply_validates_before_touching_home(self):
+        body = {"agent": "pi", "model": "missing", "backend": "llamacpp",
+                "small": "", "inject": False}
+        patches = self._patch()
+        with patches[0], patches[1], \
+             mock.patch.object(routes.os.path, "expanduser") as expanduser, \
+             mock.patch.object(routes.agentsetup, "apply") as apply, \
+             self.assertRaises(ApiError):
+            routes.post_agent_apply(Req(body=body))
+        expanduser.assert_not_called()
+        apply.assert_not_called()
+
+    def test_temporary_apply_adapter_preserves_the_current_frontend_shape(self):
+        old_body = {"agent": "pi", "model": "main", "small": ""}
+        patches = self._patch()
+        with patches[0], patches[1], \
+             mock.patch.object(
+                 routes.agentsetup, "apply",
+                 return_value={"ok": True, "path": "p", "backup": None,
+                               "action": "created"}) as apply:
+            status, _ = routes.post_agent_apply(Req(body=old_body))
+        self.assertEqual(status, 200)
+        self.assertEqual(apply.call_args.args[2], "http://127.0.0.1:8080/v1")
+
+    def test_preview_and_apply_failures_never_echo_the_router_key(self):
+        body = {"agent": "pi", "model": "main", "backend": "llamacpp",
+                "small": "", "inject": False}
+        for handler, dependency in (
+            (routes.post_agent_config, "generate"),
+            (routes.post_agent_apply, "apply"),
+        ):
+            patches = self._patch()
+            with self.subTest(handler=handler.__name__), patches[0], patches[1], \
+                 mock.patch.object(
+                     routes.agentsetup, dependency,
+                     side_effect=RuntimeError("operation failed with " + SECRET)), \
+                 self.assertRaises(ApiError) as cm:
+                handler(Req(body=body))
+            self.assertEqual(cm.exception.status, 500)
+            self.assertNotIn(SECRET, str(cm.exception))
+
+    def test_post_preview_is_registered(self):
+        self.assertIs(routes.POST_ROUTES["/api/agent/config"], routes.post_agent_config)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_client_config_route.py
+++ b/tests/test_client_config_route.py
@@ -1,0 +1,158 @@
+import conftest_paths  # noqa: F401
+import json
+import shlex
+import unittest
+from unittest import mock
+
+import clientsetup
+import routes
+from routes import ApiError, Req
+
+
+SECRET = "client-secret-" + "x" * 32
+BASE_CFG = {
+    "active_engine": "llamacpp",
+    "router_host": "127.0.0.1",
+    "router_port": 8080,
+    "router_api_key": SECRET,
+}
+
+
+class FakeRegistry:
+    def __init__(self, rows, active="llamacpp"):
+        self.rows = rows
+        self.active = active
+
+    def state(self):
+        return {"models": [dict(row) for row in self.rows], "global": {}}
+
+    def active_engine(self):
+        return self.active
+
+
+class ClientSetupGeneratorTest(unittest.TestCase):
+    def test_exact_existing_modal_snippets_are_generated(self):
+        out = clientsetup.generate(
+            "http://127.0.0.1:8080", SECRET, "qwen", "llamacpp", "posix")
+        self.assertEqual(out["endpoint"], "http://127.0.0.1:8080")
+        self.assertTrue(out["auth_required"])
+        self.assertIn("/v1/chat/completions", out["curl"])
+        self.assertIn("Authorization: Bearer " + SECRET, out["curl"])
+        self.assertIn("OPENAI_BASE_URL=http://127.0.0.1:8080/v1", out["environment"])
+        self.assertIn("OPENAI_API_KEY=" + SECRET, out["environment"])
+        self.assertEqual(json.loads(out["payload"])["model"], "qwen")
+
+    def test_unauthenticated_target_uses_not_required_marker(self):
+        out = clientsetup.generate(
+            "http://127.0.0.1:8081/", "", "v", "vllm", "posix")
+        self.assertFalse(out["auth_required"])
+        self.assertNotIn("Authorization", out["curl"])
+        self.assertIn("OPENAI_API_KEY=not-required", out["environment"])
+
+    def test_posix_curl_quotes_model_and_retained_legacy_key_as_arguments(self):
+        model = "model'; touch should-not-run"
+        key = "legacy'\"$key"
+        out = clientsetup.generate(
+            "http://127.0.0.1:8080", key, model, "llamacpp", "posix")
+        argv = shlex.split(out["curl"])
+        self.assertEqual(argv[0:2], ["curl", "http://127.0.0.1:8080/v1/chat/completions"])
+        self.assertIn("Authorization: Bearer " + key, argv)
+        self.assertEqual(json.loads(argv[-1])["model"], model)
+
+    def test_powershell_uses_single_quote_escaping_and_backtick_continuations(self):
+        out = clientsetup.generate(
+            "http://127.0.0.1:8080", "legacy'key", "m", "llamacpp", "powershell")
+        self.assertIn("legacy''key", out["curl"])
+        self.assertIn("`\n", out["curl"])
+
+
+class ClientConfigRouteTest(unittest.TestCase):
+    def _call(self, body, rows, cfg=None, active="llamacpp", vllm_status=()):
+        with mock.patch.object(routes, "REGISTRY", FakeRegistry(rows, active)), \
+             mock.patch.object(routes, "cfg", return_value=cfg or BASE_CFG), \
+             mock.patch.object(routes, "vllm_mgr") as manager:
+            manager.return_value.status.return_value = list(vllm_status)
+            return routes.post_client_config(Req(body=body))
+
+    def test_llama_target_includes_router_credential_only_on_explicit_post(self):
+        status, out = self._call(
+            {"model": "qwen", "backend": "llamacpp"},
+            [{"id": "qwen", "backend": "llamacpp", "status": "loaded"}],
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(out["backend"], "llamacpp")
+        self.assertIn(SECRET, out["curl"] + out["environment"])
+        self.assertTrue(out["model_loaded"])
+
+    def test_stale_llama_hint_snaps_to_active_family_engine(self):
+        status, out = self._call(
+            {"model": "qwen", "backend": "llamacpp"},
+            [{"id": "qwen", "backend": "ikllama", "status": "unloaded"}],
+            active="ikllama",
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(out["backend"], "ikllama")
+        self.assertFalse(out["model_loaded"])
+
+    def test_vllm_ready_target_uses_manager_endpoint_and_never_router_key(self):
+        status, out = self._call(
+            {"model": "vmodel", "backend": "vllm"},
+            [{"id": "vmodel", "backend": "vllm", "status": "loaded",
+              "endpoint": "http://caller-controlled.invalid"}],
+            vllm_status=[{"model_id": "vmodel", "state": "ready",
+                          "endpoint": "http://127.0.0.1:8081"}],
+        )
+        self.assertEqual(status, 200)
+        rendered = json.dumps(out)
+        self.assertEqual(out["endpoint"], "http://127.0.0.1:8081")
+        self.assertNotIn(SECRET, rendered)
+        self.assertNotIn("caller-controlled", rendered)
+
+    def test_vllm_unloaded_is_rejected_without_llama_fallback(self):
+        with self.assertRaises(ApiError) as cm:
+            self._call(
+                {"model": "vmodel", "backend": "vllm"},
+                [{"id": "vmodel", "backend": "vllm", "status": "offline"}],
+            )
+        self.assertEqual(cm.exception.status, 400)
+        self.assertIn("load it first", str(cm.exception))
+
+    def test_unknown_and_ambiguous_ownership_are_rejected(self):
+        with self.assertRaises(ApiError) as unknown:
+            self._call({"model": "missing"}, [])
+        self.assertEqual(unknown.exception.status, 400)
+        rows = [
+            {"id": "same", "backend": "llamacpp", "status": "loaded"},
+            {"id": "same", "backend": "vllm", "status": "loaded"},
+        ]
+        with self.assertRaises(ApiError) as ambiguous:
+            self._call({"model": "same"}, rows)
+        self.assertEqual(ambiguous.exception.status, 409)
+
+    def test_arbitrary_endpoint_and_unknown_backend_are_rejected(self):
+        rows = [{"id": "qwen", "backend": "llamacpp", "status": "loaded"}]
+        for body in (
+            {"model": "qwen", "backend": "llamacpp", "endpoint": "http://evil"},
+            {"model": "qwen", "backend": "other"},
+        ):
+            with self.subTest(body=body), self.assertRaises(ApiError) as cm:
+                self._call(body, rows)
+            self.assertEqual(cm.exception.status, 400)
+
+    def test_generation_failure_never_echoes_the_router_key(self):
+        rows = [{"id": "qwen", "backend": "llamacpp", "status": "loaded"}]
+        with mock.patch.object(
+                clientsetup, "generate",
+                side_effect=RuntimeError("generator failed with " + SECRET)), \
+             self.assertRaises(ApiError) as cm:
+            self._call({"model": "qwen", "backend": "llamacpp"}, rows)
+        self.assertEqual(cm.exception.status, 500)
+        self.assertNotIn(SECRET, str(cm.exception))
+
+    def test_route_is_post_only(self):
+        self.assertIs(routes.POST_ROUTES["/api/client/config"], routes.post_client_config)
+        self.assertNotIn("/api/client/config", routes.GET_ROUTES)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_client_config_route.py
+++ b/tests/test_client_config_route.py
@@ -1,6 +1,10 @@
 import conftest_paths  # noqa: F401
 import json
+import os
 import shlex
+import shutil
+import subprocess
+import tempfile
 import unittest
 from unittest import mock
 
@@ -54,16 +58,44 @@ class ClientSetupGeneratorTest(unittest.TestCase):
         key = "legacy'\"$key"
         out = clientsetup.generate(
             "http://127.0.0.1:8080", key, model, "llamacpp", "posix")
-        argv = shlex.split(out["curl"])
+        self.assertIn(" \\\n  ", out["curl"])
+        argv = shlex.split(out["curl"].replace("\\\n", ""))
         self.assertEqual(argv[0:2], ["curl", "http://127.0.0.1:8080/v1/chat/completions"])
         self.assertIn("Authorization: Bearer " + key, argv)
         self.assertEqual(json.loads(argv[-1])["model"], model)
 
-    def test_powershell_uses_single_quote_escaping_and_backtick_continuations(self):
+    @unittest.skipUnless(
+        os.name == "nt" and (shutil.which("powershell") or shutil.which("pwsh")),
+        "PowerShell is required for argument-preservation coverage")
+    def test_powershell_executes_adversarial_values_as_literal_arguments(self):
+        powershell = shutil.which("powershell") or shutil.which("pwsh")
+        model = "model'; Write-Error injected; # \"quoted\""
+        key = "legacy'\"$key"
         out = clientsetup.generate(
-            "http://127.0.0.1:8080", "legacy'key", "m", "llamacpp", "powershell")
-        self.assertIn("legacy''key", out["curl"])
+            "http://127.0.0.1:8080", key, model, "llamacpp", "powershell")
         self.assertIn("`\n", out["curl"])
+        with tempfile.TemporaryDirectory() as tmp:
+            recorded = os.path.join(tmp, "curl-argv.json")
+            script = os.path.join(tmp, "snippet.ps1")
+            with open(script, "w", encoding="utf-8") as f:
+                f.write(
+                    "function curl_stub {\n"
+                    "  @($args) | ConvertTo-Json -Compress | "
+                    "Set-Content -LiteralPath $env:LF_CAPTURE -NoNewline\n"
+                    "}\n"
+                    "Set-Alias curl curl_stub -Scope Global -Option AllScope -Force\n"
+                    + out["curl"] + "\n")
+            env = dict(os.environ, LF_CAPTURE=recorded)
+            result = subprocess.run(
+                [powershell, "-NoProfile", "-NonInteractive", "-File", script],
+                capture_output=True, text=True, check=False, env=env)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(os.path.exists(recorded), result.stderr + result.stdout)
+            with open(recorded, encoding="utf-8") as f:
+                argv = json.load(f)
+        self.assertEqual(argv[0:2], ["http://127.0.0.1:8080/v1/chat/completions", "-H"])
+        self.assertIn("Authorization: Bearer " + key, argv)
+        self.assertEqual(json.loads(argv[-1])["model"], model)
 
 
 class ClientConfigRouteTest(unittest.TestCase):
@@ -93,6 +125,38 @@ class ClientConfigRouteTest(unittest.TestCase):
         self.assertEqual(status, 200)
         self.assertEqual(out["backend"], "ikllama")
         self.assertFalse(out["model_loaded"])
+
+    def test_unsafe_legacy_lan_config_is_rejected(self):
+        config = dict(BASE_CFG, router_host="0.0.0.0", router_api_key="")
+        with self.assertRaises(ApiError) as cm:
+            self._call(
+                {"model": "qwen", "backend": "llamacpp"},
+                [{"id": "qwen", "backend": "llamacpp", "status": "loaded"}],
+                cfg=config,
+            )
+        self.assertEqual(cm.exception.status, 409)
+
+    def test_protected_lan_uses_canonical_lan_ip(self):
+        config = dict(BASE_CFG, router_host="0.0.0.0")
+        with mock.patch.object(routes.router_ctl, "lan_ip", return_value="192.0.2.10"):
+            status, out = self._call(
+                {"model": "qwen", "backend": "llamacpp"},
+                [{"id": "qwen", "backend": "llamacpp", "status": "loaded"}],
+                cfg=config,
+            )
+        self.assertEqual(status, 200)
+        self.assertEqual(out["endpoint"], "http://192.0.2.10:8080")
+
+    def test_protected_lan_without_an_ip_is_unavailable(self):
+        config = dict(BASE_CFG, router_host="0.0.0.0")
+        with mock.patch.object(routes.router_ctl, "lan_ip", return_value=""):
+            with self.assertRaises(ApiError) as cm:
+                self._call(
+                    {"model": "qwen", "backend": "llamacpp"},
+                    [{"id": "qwen", "backend": "llamacpp", "status": "loaded"}],
+                    cfg=config,
+                )
+        self.assertEqual(cm.exception.status, 503)
 
     def test_vllm_ready_target_uses_manager_endpoint_and_never_router_key(self):
         status, out = self._call(

--- a/tests/test_engine_switch.py
+++ b/tests/test_engine_switch.py
@@ -7,6 +7,7 @@ pointed at an engine that cannot start.
 """
 import conftest_paths  # noqa: F401
 import os
+import threading
 import unittest
 from unittest import mock
 
@@ -66,6 +67,31 @@ class EngineSwitchRouteTest(unittest.TestCase):
         self.assertEqual(self.saved["active_engine"], "ikllama")
         self.restart.assert_called_once()
         self.assertEqual(self.restart.call_args[0][0], "/opt/ik/llama-server")
+
+    def test_engine_switch_uses_shared_router_transaction_lock(self):
+        """Engine and network changes must not cross their router restarts."""
+        entered = threading.Event()
+        result = []
+
+        def load():
+            entered.set()
+            return dict(self.base, **self.saved)
+
+        def switch():
+            result.append(routes.post_engine_switch(Req(body={"engine": "llamacpp"})))
+
+        with mock.patch.object(routes, "cfg", side_effect=load), \
+             mock.patch.object(os.path, "exists", return_value=True), \
+             mock.patch.object(routes.router_ctl, "supports_router_mode", return_value=True):
+            with routes._ROUTER_LIFECYCLE_LOCK:
+                worker = threading.Thread(target=switch)
+                worker.start()
+                self.assertFalse(entered.wait(0.25))
+            worker.join(2)
+
+        self.assertFalse(worker.is_alive())
+        self.assertTrue(entered.is_set())
+        self.assertEqual(result[0][0], 200)
 
 
 class IniPathTest(unittest.TestCase):

--- a/tests/test_http_guard.py
+++ b/tests/test_http_guard.py
@@ -6,7 +6,7 @@ install packages and rewrite configuration. These tests drive a real
 ThreadingHTTPServer the way a hostile page would.
 """
 import conftest_paths  # noqa: F401
-import json, threading, unittest, urllib.error, urllib.request
+import json, socket, threading, unittest, urllib.error, urllib.request
 from http.server import ThreadingHTTPServer
 from unittest import mock
 
@@ -90,6 +90,41 @@ class LiveServerTest(unittest.TestCase):
         except urllib.error.HTTPError as e:
             return e.code, json.loads(e.read().decode() or "{}")
 
+    def _raw(self, head, body=b"", shutdown_write=True):
+        import socket
+        with socket.create_connection(("127.0.0.1", self.port), timeout=10) as sock:
+            sock.sendall(head + body)
+            if shutdown_write:
+                sock.shutdown(socket.SHUT_WR)
+            chunks = []
+            while True:
+                part = sock.recv(65536)
+                if not part:
+                    break
+                chunks.append(part)
+        raw = b"".join(chunks)
+        header, _, payload = raw.partition(b"\r\n\r\n")
+        lines = header.decode("iso-8859-1").split("\r\n")
+        status = int(lines[0].split()[1])
+        headers = {}
+        for line in lines[1:]:
+            if ":" in line:
+                key, value = line.split(":", 1)
+                headers[key.lower()] = value.strip()
+        return status, headers, payload
+
+    def _raw_post(self, path, content_length=None, extra_headers=(), body=b""):
+        lines = [
+            f"POST {path} HTTP/1.1",
+            f"Host: 127.0.0.1:{self.port}",
+            "Content-Type: application/json",
+        ]
+        if content_length is not None:
+            lines.append(f"Content-Length: {content_length}")
+        lines.extend(extra_headers)
+        head = ("\r\n".join(lines) + "\r\n\r\n").encode("ascii")
+        return self._raw(head, body)
+
     # ---------------------------------------------------------------- happy
     def test_same_origin_get_is_dispatched(self):
         status, body = self._req(
@@ -105,6 +140,82 @@ class LiveServerTest(unittest.TestCase):
         status, body = self._req("/api/_probe", "POST", data={"hello": "world"})
         self.assertEqual(status, 200)
         self.assertEqual(body["body"], {"hello": "world"})
+
+    def test_json_responses_are_no_store(self):
+        status, body = self._req("/api/_probe")
+        self.assertEqual(status, 200)
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{self.port}/api/_probe",
+            headers={"Host": f"127.0.0.1:{self.port}"})
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            self.assertEqual(resp.headers["Cache-Control"], "no-store")
+
+    def test_missing_content_length_is_411_and_closes(self):
+        status, headers, _ = self._raw_post("/api/_probe")
+        self.assertEqual(status, 411)
+        self.assertEqual(headers.get("connection"), "close")
+        self.assertEqual(self.seen, [])
+
+    def test_management_limit_is_selected_before_read(self):
+        limit = 128
+        body = b'{"x":"' + b"a" * (limit - 8) + b'"}'
+        self.assertEqual(len(body), limit)
+        with mock.patch.object(server, "MAX_MANAGEMENT_JSON_BODY_BYTES", limit):
+            status, _, _ = self._raw_post("/api/_probe", limit, body=body)
+            self.assertEqual(status, 200)
+            self.seen.clear()
+            status, headers, _ = self._raw_post("/api/_probe", limit + 1)
+        self.assertEqual(status, 413)
+        self.assertEqual(headers.get("connection"), "close")
+        self.assertEqual(self.seen, [])
+
+    def test_proxy_payload_above_management_limit_uses_proxy_limit(self):
+        prefix = b'{"model":"m","messages":[],"pad":"'
+        suffix = b'"}'
+        body = prefix + b"a" * (256 - len(prefix) - len(suffix)) + suffix
+        self.assertEqual(len(body), 256)
+        with mock.patch.object(server, "MAX_MANAGEMENT_JSON_BODY_BYTES", 96), \
+             mock.patch.object(server, "MAX_PROXY_JSON_BODY_BYTES", 256), \
+             mock.patch.object(routes, "_router_openai", return_value=(200, {"ok": True})):
+            status, _, payload = self._raw_post(
+                "/v1/chat/completions", len(body), body=body)
+        self.assertEqual(status, 200)
+        self.assertIn(b'"ok": true', payload)
+
+    def test_proxy_over_its_limit_is_413_without_read(self):
+        with mock.patch.object(server, "MAX_PROXY_JSON_BODY_BYTES", 256):
+            status, headers, _ = self._raw_post("/v1/messages", 257)
+        self.assertEqual(status, 413)
+        self.assertEqual(headers.get("connection"), "close")
+
+    def test_invalid_and_duplicate_lengths_never_dispatch(self):
+        for value in ("-1", "+1", "nope", "1x", "2 ", "2\t"):
+            with self.subTest(value=value):
+                status, headers, _ = self._raw_post("/api/_probe", value)
+                self.assertEqual(status, 400)
+                self.assertEqual(headers.get("connection"), "close")
+        duplicate = (
+            f"POST /api/_probe HTTP/1.1\r\n"
+            f"Host: 127.0.0.1:{self.port}\r\n"
+            "Content-Type: application/json\r\n"
+            "Content-Length: 2\r\nContent-Length: 2\r\n\r\n{}"
+        ).encode("ascii")
+        status, headers, _ = self._raw(duplicate)
+        self.assertEqual(status, 400)
+        self.assertEqual(headers.get("connection"), "close")
+        self.assertEqual(self.seen, [])
+
+    def test_transfer_encoding_and_short_body_close_without_dispatch(self):
+        status, headers, _ = self._raw_post(
+            "/api/_probe", None, extra_headers=("Transfer-Encoding: chunked",),
+            body=b"2\r\n{}\r\n0\r\n\r\n")
+        self.assertEqual(status, 400)
+        self.assertEqual(headers.get("connection"), "close")
+        status, headers, _ = self._raw_post("/api/_probe", 20, body=b"{}")
+        self.assertEqual(status, 400)
+        self.assertEqual(headers.get("connection"), "close")
+        self.assertEqual(self.seen, [])
+        self.assertEqual(self._req("/api/_probe")[0], 200)
 
     def test_unknown_path_404s(self):
         status, _ = self._req("/api/nope")

--- a/tests/test_http_guard.py
+++ b/tests/test_http_guard.py
@@ -205,6 +205,17 @@ class LiveServerTest(unittest.TestCase):
         self.assertEqual(headers.get("connection"), "close")
         self.assertEqual(self.seen, [])
 
+    def test_thousands_of_leading_zeroes_are_zero_length(self):
+        status, _, _ = self._raw_post("/api/_probe", "0" * 5000)
+        self.assertEqual(status, 200)
+        self.assertEqual(self.seen[-1].body, {})
+
+    def test_thousands_of_nonzero_length_digits_are_413_without_dispatch(self):
+        status, headers, _ = self._raw_post("/api/_probe", "9" * 5000)
+        self.assertEqual(status, 413)
+        self.assertEqual(headers.get("connection"), "close")
+        self.assertEqual(self.seen, [])
+
     def test_transfer_encoding_and_short_body_close_without_dispatch(self):
         status, headers, _ = self._raw_post(
             "/api/_probe", None, extra_headers=("Transfer-Encoding: chunked",),

--- a/tests/test_http_guard.py
+++ b/tests/test_http_guard.py
@@ -260,6 +260,20 @@ class LiveServerTest(unittest.TestCase):
             self.assertEqual(status, 415, ctype)
         self.assertEqual(self.seen, [])
 
+    def test_secret_preview_posts_share_origin_and_json_guards(self):
+        for path in ("/api/client/config", "/api/agent/config"):
+            with self.subTest(path=path, guard="origin"):
+                status, _ = self._req(
+                    path, method="POST", data={},
+                    headers={"Origin": "https://evil.example",
+                             "Content-Type": "application/json"})
+                self.assertEqual(status, 403)
+            with self.subTest(path=path, guard="content-type"):
+                status, _ = self._req(
+                    path, method="POST", data={},
+                    headers={"Content-Type": "application/x-www-form-urlencoded"})
+                self.assertEqual(status, 415)
+
     def test_malformed_json_is_a_400_not_a_crash(self):
         url = f"http://127.0.0.1:{self.port}/api/_probe"
         r = urllib.request.Request(

--- a/tests/test_network_policy.py
+++ b/tests/test_network_policy.py
@@ -1,0 +1,198 @@
+import conftest_paths  # noqa: F401
+import copy, json, os, re, tempfile, unittest
+from pathlib import Path
+from unittest import mock
+
+import network_policy as np
+
+
+class KeyStatusTest(unittest.TestCase):
+    def test_key_classes_are_deterministic(self):
+        cases = [
+            (None, "absent"), ("", "absent"),
+            ("a" * 32, "strong"), ("A0._~-" * 6, "strong"),
+            ("secret", "legacy"), ('quote"key', "legacy"),
+            (r"back\slash", "legacy"),
+            ("has space", "invalid"), ("tab\tkey", "invalid"),
+            ("line\nkey", "invalid"), ("nul\0key", "invalid"),
+            ("del\x7fkey", "invalid"), ("unicode-π", "invalid"),
+            ("x" * 257, "invalid"), (123, "invalid"),
+        ]
+        for value, expected in cases:
+            with self.subTest(value=repr(value)):
+                self.assertEqual(np.key_status(value), expected)
+
+    def test_generated_key_is_strong(self):
+        generated = "g" * 43
+        with mock.patch.object(np.secrets, "token_urlsafe", return_value=generated) as token:
+            key = np.generate_key()
+        token.assert_called_once_with(32)
+        self.assertIsNotNone(re.fullmatch(r"[A-Za-z0-9._~-]{32,256}", key))
+        self.assertGreaterEqual(len(key), 32)
+        self.assertLessEqual(len(key), 256)
+
+
+class AssessmentTest(unittest.TestCase):
+    def test_supported_states(self):
+        cases = [
+            ("127.0.0.1", "", "local", "local", True),
+            ("127.0.0.1", "secret", "local", "local_keyed", True),
+            ("127.0.0.1", "s" * 32, "local", "local_keyed", True),
+            ("0.0.0.0", "s" * 32, "lan", "protected", True),
+            ("0.0.0.0", "secret", "lan", "protected_legacy", True),
+        ]
+        for host, key, scope, status, allowed in cases:
+            with self.subTest(host=host, key_status=np.key_status(key)):
+                out = np.assess(host, key)
+                self.assertEqual(out.access_scope, scope)
+                self.assertEqual(out.configured_security_status, status)
+                self.assertEqual(out.start_allowed, allowed)
+                self.assertNotIn(key, repr(out)) if key else None
+
+    def test_unsafe_states_never_start(self):
+        invalid_lan_keys = [
+            "", "bad key", "tab\tkey", "line\nkey", "nul\0key",
+            "del\x7fkey", "unicode-π", "x" * 257, 123,
+        ]
+        for host, key in [
+            *(("0.0.0.0", key) for key in invalid_lan_keys),
+            ("192.168.1.20", "s" * 32), ("localhost", ""),
+            ("::", "s" * 32), (None, ""),
+        ]:
+            with self.subTest(host=host):
+                out = np.assess(host, key)
+                self.assertEqual(out.access_scope, "legacy")
+                self.assertEqual(out.configured_security_status, "unsafe_legacy")
+                self.assertTrue(out.remediation_required)
+                self.assertFalse(out.start_allowed)
+                self.assertTrue(np.start_error(host, key))
+
+
+class MutationTest(unittest.TestCase):
+    def test_keep_preserves_a_legacy_lan_key(self):
+        out = np.apply_request(
+            {"router_host": "0.0.0.0", "router_api_key": "secret"},
+            {"access_scope": "lan", "key_action": "keep"})
+        self.assertEqual(out.router_host, "0.0.0.0")
+        self.assertEqual(out.router_api_key, "secret")
+        self.assertIsNone(out.generated_api_key)
+
+    def test_generate_returns_the_same_strong_key_it_selects(self):
+        generated = "g" * 43
+        current = {"router_host": "127.0.0.1", "router_api_key": ""}
+        body = {"access_scope": "lan", "key_action": "generate"}
+        current_before, body_before = copy.deepcopy(current), copy.deepcopy(body)
+        with mock.patch.object(np.secrets, "token_urlsafe", return_value=generated) as token:
+            out = np.apply_request(
+                current, body)
+        token.assert_called_once_with(32)
+        self.assertEqual(out.router_api_key, generated)
+        self.assertEqual(out.generated_api_key, generated)
+        self.assertEqual(out.assessment.configured_security_status, "protected")
+        self.assertEqual(current, current_before)
+        self.assertEqual(body, body_before)
+
+    def test_replace_requires_a_new_strong_key(self):
+        current = {"router_host": "127.0.0.1", "router_api_key": ""}
+        with self.assertRaisesRegex(ValueError, "strong"):
+            np.apply_request(current, {
+                "access_scope": "lan", "key_action": "replace",
+                "api_key": "short"})
+        out = np.apply_request(current, {
+            "access_scope": "lan", "key_action": "replace",
+            "api_key": "r" * 32})
+        self.assertEqual(out.router_api_key, "r" * 32)
+
+    def test_clear_is_local_only(self):
+        current = {"router_host": "0.0.0.0", "router_api_key": "s" * 32}
+        with self.assertRaisesRegex(ValueError, "local"):
+            np.apply_request(current, {
+                "access_scope": "lan", "key_action": "clear"})
+        out = np.apply_request(current, {
+            "access_scope": "local", "key_action": "clear"})
+        self.assertEqual((out.router_host, out.router_api_key),
+                         ("127.0.0.1", ""))
+
+    def test_contradictory_and_unknown_fields_are_rejected(self):
+        current = {"router_host": "127.0.0.1", "router_api_key": ""}
+        bad = [
+            {"access_scope": "lan", "key_action": "generate", "api_key": "x" * 32},
+            {"access_scope": "lan", "key_action": "replace"},
+            {"access_scope": "public", "key_action": "keep"},
+            {"access_scope": "local", "key_action": "erase"},
+            {"access_scope": "local", "key_action": "keep", "extra": True},
+            {"access_scope": "local", "host": "127.0.0.1"},
+        ]
+        for body in bad:
+            with self.subTest(body=body), self.assertRaises(ValueError):
+                np.apply_request(current, body)
+
+    def test_old_shape_maps_only_the_two_canonical_hosts(self):
+        current = {"router_host": "127.0.0.1", "router_api_key": "k" * 32}
+        kept = np.apply_request(current, {"host": "0.0.0.0"})
+        self.assertEqual((kept.access_scope, kept.key_action), ("lan", "keep"))
+        cleared = np.apply_request(current, {"host": "127.0.0.1", "api_key": ""})
+        self.assertEqual(cleared.router_api_key, "")
+        with self.assertRaises(ValueError):
+            np.apply_request(current, {"host": "192.168.1.20"})
+        with self.assertRaises(ValueError):
+            np.apply_request({"router_api_key": ""}, {"host": "0.0.0.0"})
+
+    def test_mutation_requests_do_not_modify_inputs(self):
+        cases = [
+            ({"router_host": "0.0.0.0", "router_api_key": "secret"},
+             {"access_scope": "lan", "key_action": "keep"}),
+            ({"router_host": "127.0.0.1", "router_api_key": ""},
+             {"access_scope": "lan", "key_action": "replace", "api_key": "r" * 32}),
+            ({"router_host": "0.0.0.0", "router_api_key": "s" * 32},
+             {"access_scope": "local", "key_action": "clear"}),
+        ]
+        for current, body in cases:
+            with self.subTest(body=body):
+                current_before, body_before = copy.deepcopy(current), copy.deepcopy(body)
+                np.apply_request(current, body)
+                self.assertEqual(current, current_before)
+                self.assertEqual(body, body_before)
+
+
+class ProjectionAndCliTest(unittest.TestCase):
+    def test_public_projection_is_allowlisted_and_redacted(self):
+        cfg = {
+            "theme": "dark", "cvd": True, "auto_load_model": "m",
+            "vram_bandwidths": {"vram_bw": 900}, "presets": {"fast": {}},
+            "preset_bindings": {"llamacpp": {"m": "fast"}},
+            "active_engine": "llamacpp", "router_api_key": "do-not-return",
+            "server_bin": "C:/private/server.exe", "future_secret": "hidden",
+        }
+        out = np.public_config(cfg)
+        self.assertEqual(set(out), {
+            "theme", "cvd", "auto_load_model", "vram_bandwidths", "presets",
+            "preset_bindings", "active_engine", "router_api_key_configured"})
+        self.assertTrue(out["router_api_key_configured"])
+        self.assertNotIn("do-not-return", repr(out))
+        out["vram_bandwidths"]["vram_bw"] = 1
+        out["presets"]["fast"]["changed"] = True
+        out["preset_bindings"]["llamacpp"]["m"] = "changed"
+        self.assertEqual(cfg["vram_bandwidths"]["vram_bw"], 900)
+        self.assertEqual(cfg["presets"], {"fast": {}})
+        self.assertEqual(cfg["preset_bindings"]["llamacpp"]["m"], "fast")
+
+    def test_preflight_never_rewrites_and_cli_status_is_truthful(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "config.json")
+            unsafe = {"router_host": "0.0.0.0", "router_api_key": ""}
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(unsafe, f)
+            before = Path(path).read_bytes()
+            ok, message = np.preflight_config_file(path)
+            self.assertFalse(ok)
+            self.assertIn("API key", message)
+            self.assertEqual(Path(path).read_bytes(), before)
+            self.assertNotEqual(np.main(["--preflight", path]), 0)
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump({"router_host": "127.0.0.1", "router_api_key": ""}, f)
+            self.assertEqual(np.main(["--preflight", path]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_network_routes.py
+++ b/tests/test_network_routes.py
@@ -1,5 +1,6 @@
 import conftest_paths  # noqa: F401
 import json
+import threading
 import unittest
 from unittest import mock
 
@@ -226,6 +227,97 @@ class PostNetworkRouteTest(unittest.TestCase):
         redacted = dict(out)
         redacted.pop("generated_api_key")
         self.assertNotIn(SECRET, json.dumps(redacted))
+
+    def test_network_changes_are_one_serialized_router_transaction(self):
+        """A second tab must not read or restart during the first change."""
+        original = "original-route-key-" + "o" * 20
+        generated = "generated-route-key-" + "g" * 20
+        state = {
+            "router_host": "0.0.0.0", "router_api_key": original,
+            "router_port": 8080, "server_bin": "server",
+        }
+        first_restart_entered = threading.Event()
+        release_first_restart = threading.Event()
+        second_cfg_read = threading.Event()
+        cfg_reads = 0
+        restart_keys = []
+        results = []
+
+        def load_current():
+            nonlocal cfg_reads
+            cfg_reads += 1
+            if cfg_reads == 2:
+                second_cfg_read.set()
+            return dict(state)
+
+        def persist(changes):
+            state.update(changes)
+            return dict(state)
+
+        def restart(*args):
+            restart_keys.append(args[4])
+            if len(restart_keys) == 1:
+                first_restart_entered.set()
+                self.assertTrue(release_first_restart.wait(2))
+            return True, ""
+
+        def change(body):
+            try:
+                results.append(routes.post_network(Req(body=body)))
+            except Exception as exc:  # make worker failures visible to the test
+                results.append(exc)
+
+        with mock.patch.object(routes, "cfg", side_effect=load_current), \
+             mock.patch.object(routes.network_policy, "generate_key",
+                               return_value=generated), \
+             mock.patch.object(config, "update", side_effect=persist), \
+             mock.patch.object(routes.router_ctl, "restart", side_effect=restart), \
+             mock.patch.object(routes.router_ctl, "is_running", return_value=True), \
+             mock.patch.object(routes.router_ctl, "lan_ip", return_value="192.168.1.9"):
+            first = threading.Thread(target=change, args=({
+                "access_scope": "lan", "key_action": "generate"},))
+            second = threading.Thread(target=change, args=({
+                "access_scope": "lan", "key_action": "keep"},))
+            first.start()
+            self.assertTrue(first_restart_entered.wait(2))
+            second.start()
+            try:
+                self.assertFalse(
+                    second_cfg_read.wait(0.25),
+                    "second request read config while first restart was in flight")
+            finally:
+                release_first_restart.set()
+            first.join(2)
+            second.join(2)
+
+        self.assertFalse(first.is_alive())
+        self.assertFalse(second.is_alive())
+        self.assertEqual(len(results), 2)
+        self.assertTrue(all(not isinstance(result, Exception)
+                            for result in results), results)
+        self.assertEqual(restart_keys, [generated, generated])
+        self.assertEqual(state["router_api_key"], generated)
+
+    def test_socket_construction_failure_does_not_lose_generated_key(self):
+        current = {"router_host": "127.0.0.1", "router_api_key": "",
+                   "router_port": 8080, "server_bin": "server"}
+
+        with mock.patch.object(routes, "cfg", return_value=current), \
+             mock.patch.object(routes.network_policy, "generate_key",
+                               return_value=SECRET), \
+             mock.patch.object(config, "update",
+                               return_value=dict(current, router_host="0.0.0.0",
+                                                 router_api_key=SECRET)), \
+             mock.patch.object(routes.router_ctl, "restart", return_value=(True, "")), \
+             mock.patch.object(routes.router_ctl, "is_running", return_value=True), \
+             mock.patch.object(routes.router_ctl.socket, "socket",
+                               side_effect=OSError("socket table exhausted")):
+            status, out = routes.post_network(Req(body={
+                "access_scope": "lan", "key_action": "generate"}))
+
+        self.assertEqual(status, 200)
+        self.assertEqual(out["generated_api_key"], SECRET)
+        self.assertIsNone(out["lan_ip"])
 
     def test_old_shape_is_narrow_and_still_fails_closed(self):
         current = {"router_host": "127.0.0.1", "router_api_key": SECRET,

--- a/tests/test_network_routes.py
+++ b/tests/test_network_routes.py
@@ -176,6 +176,29 @@ class PostNetworkRouteTest(unittest.TestCase):
         update.assert_not_called()
         restart.assert_not_called()
 
+    def test_save_failure_is_generic_and_stops_before_lifecycle_work(self):
+        current = {"router_host": "127.0.0.1", "router_api_key": "",
+                   "router_port": 8080, "server_bin": "server"}
+        with mock.patch.object(routes, "cfg", return_value=current), \
+             mock.patch.object(
+                 config, "update",
+                 side_effect=OSError("save refused with " + SECRET)) as update, \
+             mock.patch.object(routes.router_ctl, "restart") as restart, \
+             mock.patch.object(routes.router_ctl, "is_running") as running, \
+             mock.patch.object(routes.router_ctl, "lan_ip") as lan_ip, \
+             self.assertRaises(ApiError) as cm:
+            routes.post_network(Req(body={
+                "access_scope": "lan", "key_action": "replace",
+                "api_key": SECRET}))
+        self.assertEqual(cm.exception.status, 500)
+        self.assertEqual(str(cm.exception), "network settings could not be saved")
+        self.assertNotIn(SECRET, str(cm.exception))
+        update.assert_called_once_with({
+            "router_host": "0.0.0.0", "router_api_key": SECRET})
+        restart.assert_not_called()
+        running.assert_not_called()
+        lan_ip.assert_not_called()
+
     def test_restart_exception_still_returns_saved_generated_key_once(self):
         current = {"router_host": "127.0.0.1", "router_api_key": "",
                    "router_port": 8080, "server_bin": "server"}

--- a/tests/test_network_routes.py
+++ b/tests/test_network_routes.py
@@ -1,0 +1,228 @@
+import conftest_paths  # noqa: F401
+import json
+import unittest
+from unittest import mock
+
+import config
+import routes
+from routes import ApiError, Req
+
+
+SECRET = "route-secret-" + "r" * 32
+
+
+class GetNetworkRouteTest(unittest.TestCase):
+    def test_supported_stored_conditions_map_to_redacted_status(self):
+        cases = [
+            ("127.0.0.1", "", "local", "local"),
+            ("127.0.0.1", "legacy-route-key", "local", "local_keyed"),
+            ("127.0.0.1", "s" * 32, "local", "local_keyed"),
+            ("0.0.0.0", "legacy-route-key", "lan", "protected_legacy"),
+            ("0.0.0.0", "s" * 32, "lan", "protected"),
+        ]
+        for host, key, scope, configured in cases:
+            stored = {"router_host": host, "router_api_key": key,
+                      "router_port": 8080}
+            with self.subTest(host=host, configured=configured), \
+                 mock.patch.object(routes, "cfg", return_value=stored), \
+                 mock.patch.object(routes.router_ctl, "lan_ip",
+                                   return_value="192.168.1.9"), \
+                 mock.patch.object(routes.router_ctl, "is_running",
+                                   return_value=False):
+                status, out = routes.get_network(Req())
+            self.assertEqual(status, 200)
+            self.assertEqual(out["access_scope"], scope)
+            self.assertEqual(out["configured_security_status"], configured)
+            if key:
+                self.assertNotIn(key, json.dumps(out))
+
+    def test_unsafe_legacy_is_redacted_and_observation_is_qualified(self):
+        stored = {
+            "router_host": "192.168.1.50",
+            "router_api_key": SECRET,
+            "router_port": 8080,
+        }
+        with mock.patch.object(routes, "cfg", return_value=stored), \
+             mock.patch.object(routes.router_ctl, "lan_ip", return_value="192.168.1.9"), \
+             mock.patch.object(routes.router_ctl, "is_running", return_value=True), \
+             mock.patch.object(config, "update") as update:
+            status, out = routes.get_network(Req())
+        self.assertEqual(status, 200)
+        self.assertEqual(out["access_scope"], "legacy")
+        self.assertEqual(out["configured_security_status"], "unsafe_legacy")
+        self.assertEqual(out["listener_status"], "listening")
+        self.assertTrue(out["router_running"])
+        self.assertTrue(out["remediation_required"])
+        self.assertNotIn(SECRET, json.dumps(out))
+        self.assertNotIn("router_api_key", out)
+        update.assert_not_called()
+
+
+class PostNetworkRouteTest(unittest.TestCase):
+    def _call(self, current, body, restart=(True, ""), running=False):
+        saved = {}
+        updated = dict(current)
+
+        def persist(changes):
+            saved.update(changes)
+            updated.update(changes)
+            return dict(updated)
+
+        with mock.patch.object(routes, "cfg", return_value=current), \
+             mock.patch.object(config, "update", side_effect=persist) as update, \
+             mock.patch.object(routes.router_ctl, "restart",
+                               return_value=restart) as restart_call, \
+             mock.patch.object(routes.router_ctl, "is_running",
+                               return_value=running), \
+             mock.patch.object(routes.router_ctl, "lan_ip",
+                               return_value="192.168.1.9"):
+            result = routes.post_network(Req(body=body))
+        return result, saved, update, restart_call
+
+    def test_invalid_transition_neither_saves_nor_restarts(self):
+        current = {"router_host": "127.0.0.1", "router_api_key": "",
+                   "router_port": 8080, "server_bin": "server"}
+        with mock.patch.object(routes, "cfg", return_value=current), \
+             mock.patch.object(config, "update") as update, \
+             mock.patch.object(routes.router_ctl, "restart") as restart:
+            with self.assertRaises(ApiError) as cm:
+                routes.post_network(Req(body={
+                    "access_scope": "lan", "key_action": "keep"}))
+        self.assertEqual(cm.exception.status, 400)
+        update.assert_not_called()
+        restart.assert_not_called()
+
+    def test_generate_saves_before_restart_and_returns_key_once(self):
+        current = {"router_host": "127.0.0.1", "router_api_key": "",
+                   "router_port": 8080, "server_bin": "server"}
+        events = []
+
+        def persist(changes):
+            events.append("save")
+            return dict(current, **changes)
+
+        def restart(*args):
+            events.append("restart")
+            return True, ""
+
+        with mock.patch.object(routes, "cfg", return_value=current), \
+             mock.patch.object(routes.network_policy, "generate_key",
+                               return_value=SECRET), \
+             mock.patch.object(config, "update", side_effect=persist), \
+             mock.patch.object(routes.router_ctl, "restart", side_effect=restart), \
+             mock.patch.object(routes.router_ctl, "is_running", return_value=False), \
+             mock.patch.object(routes.router_ctl, "lan_ip", return_value="192.168.1.9"):
+            status, out = routes.post_network(Req(body={
+                "access_scope": "lan", "key_action": "generate"}))
+        self.assertEqual(status, 200)
+        self.assertEqual(events, ["save", "restart"])
+        self.assertEqual(out["generated_api_key"], SECRET)
+        self.assertEqual(out["restart_status"], "starting")
+        self.assertFalse(out["router_running"])
+        redacted = dict(out)
+        redacted.pop("generated_api_key")
+        self.assertNotIn(SECRET, json.dumps(redacted))
+
+    def test_replace_restarts_with_exact_validated_settings(self):
+        current = {"router_host": "127.0.0.1", "router_api_key": "",
+                   "router_port": 8080, "server_bin": "server",
+                   "models_ini": "models.ini"}
+        (status, out), saved, _, restart = self._call(
+            current,
+            {"access_scope": "lan", "key_action": "replace",
+             "api_key": SECRET},
+            running=True,
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(saved, {
+            "router_host": "0.0.0.0", "router_api_key": SECRET})
+        self.assertEqual(restart.call_args.args[3:5], ("0.0.0.0", SECRET))
+        self.assertEqual(out["restart_status"], "running")
+        self.assertTrue(out["ok"])
+        self.assertNotIn("generated_api_key", out)
+        self.assertNotIn(SECRET, json.dumps(out))
+
+    def test_failed_restart_is_saved_not_running_and_scrubs_error(self):
+        current = {"router_host": "127.0.0.1", "router_api_key": SECRET,
+                   "router_port": 8080, "server_bin": "server"}
+        (status, out), saved, _, _ = self._call(
+            current,
+            {"access_scope": "lan", "key_action": "keep"},
+            restart=(False, "could not launch with " + SECRET),
+            running=False,
+        )
+        self.assertEqual(status, 500)
+        self.assertEqual(saved["router_host"], "0.0.0.0")
+        self.assertFalse(out["ok"])
+        self.assertTrue(out["saved"])
+        self.assertEqual(out["restart_status"], "failed")
+        self.assertEqual(out["configured_security_status"], "protected")
+        self.assertNotIn(SECRET, json.dumps(out))
+
+    def test_generation_failure_is_generic_and_never_mutates(self):
+        current = {"router_host": "127.0.0.1", "router_api_key": "",
+                   "router_port": 8080, "server_bin": "server"}
+        with mock.patch.object(routes, "cfg", return_value=current), \
+             mock.patch.object(
+                 routes.network_policy, "generate_key",
+                 side_effect=RuntimeError("generation failed with " + SECRET)), \
+             mock.patch.object(config, "update") as update, \
+             mock.patch.object(routes.router_ctl, "restart") as restart, \
+             self.assertRaises(ApiError) as cm:
+            routes.post_network(Req(body={
+                "access_scope": "lan", "key_action": "generate"}))
+        self.assertEqual(cm.exception.status, 500)
+        self.assertNotIn(SECRET, str(cm.exception))
+        update.assert_not_called()
+        restart.assert_not_called()
+
+    def test_restart_exception_still_returns_saved_generated_key_once(self):
+        current = {"router_host": "127.0.0.1", "router_api_key": "",
+                   "router_port": 8080, "server_bin": "server"}
+        updated = dict(current)
+
+        def persist(changes):
+            updated.update(changes)
+            return dict(updated)
+
+        with mock.patch.object(routes, "cfg", return_value=current), \
+             mock.patch.object(routes.network_policy, "generate_key",
+                               return_value=SECRET), \
+             mock.patch.object(config, "update", side_effect=persist), \
+             mock.patch.object(
+                 routes.router_ctl, "restart",
+                 side_effect=PermissionError("launch refused with " + SECRET)), \
+             mock.patch.object(routes.router_ctl, "is_running", return_value=False), \
+             mock.patch.object(routes.router_ctl, "lan_ip", return_value="192.168.1.9"):
+            status, out = routes.post_network(Req(body={
+                "access_scope": "lan", "key_action": "generate"}))
+        self.assertEqual(status, 500)
+        self.assertTrue(out["saved"])
+        self.assertEqual(out["restart_status"], "failed")
+        self.assertEqual(out["generated_api_key"], SECRET)
+        redacted = dict(out)
+        redacted.pop("generated_api_key")
+        self.assertNotIn(SECRET, json.dumps(redacted))
+
+    def test_old_shape_is_narrow_and_still_fails_closed(self):
+        current = {"router_host": "127.0.0.1", "router_api_key": SECRET,
+                   "router_port": 8080, "server_bin": "server"}
+        (status, _), saved, _, _ = self._call(
+            current, {"host": "0.0.0.0"}, running=True)
+        self.assertEqual(status, 200)
+        self.assertEqual(saved["router_api_key"], SECRET)
+        for body in ({"host": "192.168.1.9"},
+                     {"host": "0.0.0.0", "api_key": ""}):
+            with self.subTest(body=body), \
+                 mock.patch.object(routes, "cfg",
+                                   return_value=dict(current, router_api_key="")), \
+                 mock.patch.object(config, "update") as update, \
+                 mock.patch.object(routes.router_ctl, "restart") as restart, \
+                 self.assertRaises(ApiError):
+                routes.post_network(Req(body=body))
+            update.assert_not_called()
+            restart.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_router_network_preflight.py
+++ b/tests/test_router_network_preflight.py
@@ -1,0 +1,77 @@
+import conftest_paths  # noqa: F401
+import unittest
+from unittest import mock
+
+import router_ctl
+
+
+class RouterStartPreflightTest(unittest.TestCase):
+    def test_unsafe_start_touches_no_binary_port_log_or_process(self):
+        with mock.patch.object(router_ctl.os.path, "exists") as exists, \
+             mock.patch.object(router_ctl, "is_running") as running, \
+             mock.patch.object(router_ctl.os, "makedirs") as makedirs, \
+             mock.patch("builtins.open") as open_file, \
+             mock.patch.object(router_ctl.subprocess, "Popen") as popen:
+            ok, error = router_ctl.start(
+                "server", "models.ini", 8080, "0.0.0.0", "", "logs")
+        self.assertFalse(ok)
+        self.assertIn("API key", error)
+        exists.assert_not_called()
+        running.assert_not_called()
+        makedirs.assert_not_called()
+        open_file.assert_not_called()
+        popen.assert_not_called()
+
+    def test_valid_lan_start_reaches_spawn_and_passes_key(self):
+        key = "k" * 32
+        handles = mock.mock_open()
+        with mock.patch.object(router_ctl.os.path, "exists", return_value=True), \
+             mock.patch.object(router_ctl, "is_running", return_value=False), \
+             mock.patch.object(router_ctl.os, "makedirs"), \
+             mock.patch("builtins.open", handles), \
+             mock.patch.object(router_ctl.subprocess, "Popen") as popen:
+            ok, error = router_ctl.start(
+                "server", "models.ini", 8080, "0.0.0.0", key, "logs")
+        self.assertTrue(ok, error)
+        argv = popen.call_args.args[0]
+        self.assertEqual(argv[argv.index("--host") + 1], "0.0.0.0")
+        self.assertEqual(argv[argv.index("--api-key") + 1], key)
+
+
+class RouterRestartPreflightTest(unittest.TestCase):
+    def test_unsafe_restart_does_not_lookup_stop_kill_or_spawn(self):
+        with mock.patch.object(router_ctl, "_pid_on_port") as pid, \
+             mock.patch.object(router_ctl, "_kill") as kill, \
+             mock.patch.object(router_ctl, "stop") as stop, \
+             mock.patch.object(router_ctl.os.path, "exists") as exists, \
+             mock.patch.object(router_ctl.subprocess, "Popen") as popen:
+            ok, error = router_ctl.restart(
+                "server", "models.ini", 8080, "0.0.0.0", "", "logs")
+        self.assertFalse(ok)
+        self.assertIn("API key", error)
+        pid.assert_not_called()
+        kill.assert_not_called()
+        stop.assert_not_called()
+        exists.assert_not_called()
+        popen.assert_not_called()
+
+    def test_valid_restart_stops_only_after_preflight_then_calls_start(self):
+        key = "s" * 32
+        events = []
+        with mock.patch.object(
+                router_ctl.network_policy, "start_error",
+                side_effect=lambda host, api_key: events.append("preflight") or ""), \
+             mock.patch.object(
+                router_ctl, "stop",
+                side_effect=lambda port: events.append("stop") or True), \
+             mock.patch.object(
+                router_ctl, "start",
+                side_effect=lambda *args: events.append("start") or (True, "")):
+            ok, error = router_ctl.restart(
+                "server", "models.ini", 8080, "0.0.0.0", key, "logs")
+        self.assertTrue(ok, error)
+        self.assertEqual(events, ["preflight", "stop", "start"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_routes_api.py
+++ b/tests/test_routes_api.py
@@ -205,6 +205,67 @@ class HubAddTest(unittest.TestCase):
                          ["a.gguf", "b.gguf"])       # .txt not registered
 
 
+class PublicConfigProjectionTest(unittest.TestCase):
+    def setUp(self):
+        self.secret = "projection-secret-" + "p" * 32
+        self.stored = {
+            "theme": "dark",
+            "cvd": True,
+            "auto_load_model": "llama-fixture",
+            "vram_bandwidths": {"vram_bw": 900.0},
+            "presets": {"fast": {"temp": "0.2"}},
+            "preset_bindings": {"llamacpp": {"llama-fixture": "fast"}},
+            "active_engine": "llamacpp",
+            "router_api_key": self.secret,
+            "router_host": "0.0.0.0",
+            "router_port": 8080,
+            "panel_port": 8090,
+            "server_bin": "private-server",
+            "future_secret": "private-future-value",
+        }
+
+    def test_projection_is_exact_allowlist_and_never_returns_key(self):
+        out = routes._public_config(self.stored)
+        self.assertEqual(set(out), {
+            "theme", "cvd", "auto_load_model", "vram_bandwidths",
+            "presets", "preset_bindings", "active_engine",
+            "router_api_key_configured",
+        })
+        self.assertTrue(out["router_api_key_configured"])
+        self.assertNotIn(self.secret, repr(out))
+        self.assertNotIn("router_api_key", out)
+
+    def test_state_uses_the_same_projection(self):
+        registry = mock.Mock()
+        registry.state.return_value = {"models": [], "global": {}}
+        registry.enabled.return_value = []
+        with mock.patch.object(routes, "cfg", return_value=self.stored), \
+             mock.patch.object(routes, "REGISTRY", registry), \
+             mock.patch.object(routes, "_gpu_telemetry", return_value=[]), \
+             mock.patch.object(routes.os.path, "exists", return_value=True):
+            status, out = routes.get_state(Req())
+        self.assertEqual(status, 200)
+        self.assertEqual(out["config"], routes._public_config(self.stored))
+        self.assertNotIn(self.secret, repr(out))
+
+    def test_successful_config_post_uses_the_same_projection(self):
+        updated = dict(self.stored, theme="light")
+        with mock.patch.object(config, "update", return_value=updated):
+            status, out = routes.post_config(Req(body={"theme": "light"}))
+        self.assertEqual(status, 200)
+        self.assertEqual(out["config"], routes._public_config(updated))
+        self.assertNotIn(self.secret, repr(out))
+
+
+class ExplicitSecretRouteTableTest(unittest.TestCase):
+    def test_agent_preview_get_is_removed_and_posts_are_present(self):
+        self.assertNotIn("/api/agent/config", routes.GET_ROUTES)
+        self.assertIs(routes.POST_ROUTES["/api/agent/config"],
+                      routes.post_agent_config)
+        self.assertIs(routes.POST_ROUTES["/api/client/config"],
+                      routes.post_client_config)
+
+
 class RouteTableTest(unittest.TestCase):
     def test_every_route_maps_to_a_callable(self):
         for table in (routes.GET_ROUTES, routes.POST_ROUTES):

--- a/tests/test_runner_preflight.py
+++ b/tests/test_runner_preflight.py
@@ -1,0 +1,199 @@
+import conftest_paths  # noqa: F401
+import json
+import os
+import pathlib
+import shutil
+import socket
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+POWERSHELL = shutil.which("pwsh") or shutil.which("powershell")
+
+
+def _free_port():
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _wait_for(path, seconds=5):
+    deadline = time.time() + seconds
+    while time.time() < deadline:
+        if path.exists():
+            return True
+        time.sleep(0.05)
+    return path.exists()
+
+
+class RunnerSourceContractTest(unittest.TestCase):
+    def test_windows_prefers_py_falls_back_and_reuses_resolution(self):
+        text = (ROOT / "run.ps1").read_text(encoding="utf-8-sig")
+        self.assertLess(text.index("Get-Command py"), text.index("Get-Command python"))
+        self.assertIn(r"backend\network_policy.py", text)
+        self.assertIn("Test-LlamaForgePython", text)
+        self.assertIn("& $pythonFile @preflightArgs", text)
+        self.assertIn("-FilePath $pythonFile", text)
+        self.assertIn("LLAMAFORGE_NO_BROWSER", text)
+
+    def test_posix_preflights_with_python3_and_keeps_dashboard_after_guard(self):
+        text = (ROOT / "run.sh").read_text(encoding="utf-8")
+        preflight = 'python3 "$here/backend/network_policy.py" --preflight "$cfg"'
+        panel = '(cd "$here/backend" && nohup python3 server.py'
+        self.assertIn(preflight, text)
+        self.assertIn(panel, text)
+        self.assertLess(text.index(preflight), text.index(panel))
+        self.assertIn("LLAMAFORGE_NO_BROWSER", text)
+
+
+class RunnerIntegrationMixin:
+    runner_name = ""
+
+    def setUp(self):
+        self.tmp_obj = tempfile.TemporaryDirectory()
+        self.tmp = pathlib.Path(self.tmp_obj.name)
+        self.backend = self.tmp / "backend"
+        self.backend.mkdir()
+        shutil.copy2(ROOT / "backend" / "network_policy.py",
+                     self.backend / "network_policy.py")
+        shutil.copy2(ROOT / self.runner_name, self.tmp / self.runner_name)
+        self.router_marker = self.tmp / "router-started"
+        self.panel_marker = self.tmp / "panel-started"
+        self.bad_py_marker = self.tmp / "bad-py-probed"
+        (self.backend / "server.py").write_text(
+            "import os\n"
+            "open(os.environ['RUNNER_PANEL_MARKER'], 'w').write('started')\n",
+            encoding="utf-8",
+        )
+        self.router_port = _free_port()
+        self.panel_port = _free_port()
+        self.models_ini = self.tmp / "models.ini"
+        if os.name == "nt":
+            self.server_bin = self.tmp / "fake-router.cmd"
+            self.server_bin.write_text(
+                "@echo off\r\n"
+                "@echo started>\"%RUNNER_ROUTER_MARKER%\"\r\n",
+                encoding="utf-8",
+            )
+        else:
+            self.server_bin = self.tmp / "fake-router"
+            self.server_bin.write_text(
+                "#!/bin/sh\nprintf started > \"$RUNNER_ROUTER_MARKER\"\n",
+                encoding="utf-8",
+            )
+            self.server_bin.chmod(
+                self.server_bin.stat().st_mode | stat.S_IXUSR)
+        config = {
+            "router_port": self.router_port,
+            "panel_port": self.panel_port,
+            "router_host": "0.0.0.0",
+            "router_api_key": "",
+            "server_bin": str(self.server_bin),
+            "models_ini": str(self.models_ini),
+            "active_engine": "llamacpp",
+        }
+        (self.tmp / "config.json").write_text(
+            json.dumps(config), encoding="utf-8")
+
+    def tearDown(self):
+        for _ in range(20):
+            try:
+                self.tmp_obj.cleanup()
+                return
+            except PermissionError:
+                time.sleep(0.05)
+        self.tmp_obj.cleanup()
+
+    def _environment(self, reported_listener=-1):
+        env = os.environ.copy()
+        env.update({
+            "RUNNER_ROUTER_MARKER": str(self.router_marker),
+            "RUNNER_PANEL_MARKER": str(self.panel_marker),
+            "RUNNER_LISTEN_PORT": str(reported_listener),
+            "LLAMAFORGE_NO_BROWSER": "1",
+        })
+        if os.name == "nt":
+            tools = self.tmp / "test-bin"
+            tools.mkdir(exist_ok=True)
+            (tools / "py.cmd").write_text(
+                "@echo off\r\n"
+                "@echo probed>\"%RUNNER_BAD_PY_MARKER%\"\r\n"
+                "@exit /b 9\r\n",
+                encoding="utf-8",
+            )
+            (tools / "python.cmd").write_text(
+                f"@echo off\r\n@\"{sys.executable}\" %*\r\n",
+                encoding="utf-8",
+            )
+            env["RUNNER_BAD_PY_MARKER"] = str(self.bad_py_marker)
+            env["PATH"] = str(tools) + os.pathsep + env.get("PATH", "")
+            env["PATHEXT"] = ".CMD;" + env.get("PATHEXT", "")
+        else:
+            tools = self.tmp / "test-bin"
+            tools.mkdir(exist_ok=True)
+            lsof = tools / "lsof"
+            lsof.write_text(
+                "#!/bin/sh\n"
+                "case \"$*\" in *\"tcp:$RUNNER_LISTEN_PORT\"*) exit 0;; "
+                "*) exit 1;; esac\n",
+                encoding="utf-8",
+            )
+            lsof.chmod(lsof.stat().st_mode | stat.S_IXUSR)
+            env["PATH"] = str(tools) + os.pathsep + env.get("PATH", "")
+        return env
+
+    def _run(self, reported_listener=-1):
+        env = self._environment(reported_listener)
+        if os.name == "nt":
+            cmd = [POWERSHELL, "-NoProfile", "-File",
+                   str(self.tmp / self.runner_name)]
+        else:
+            cmd = ["bash", str(self.tmp / self.runner_name)]
+        return subprocess.run(
+            cmd, cwd=self.tmp, env=env, text=True,
+            capture_output=True, timeout=20, check=False)
+
+    def test_unsafe_new_router_is_skipped_but_dashboard_starts(self):
+        result = self._run()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(self.router_marker.exists())
+        self.assertTrue(_wait_for(self.panel_marker), result.stdout + result.stderr)
+        self.assertIn("repair Network Access", result.stdout + result.stderr)
+
+    def test_existing_listener_is_left_reachable(self):
+        held = socket.socket()
+        held.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        held.bind(("127.0.0.1", self.router_port))
+        held.listen()
+        self.addCleanup(held.close)
+        result = self._run(reported_listener=self.router_port)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(self.router_marker.exists())
+        with socket.create_connection(("127.0.0.1", self.router_port), timeout=2):
+            pass
+
+    @unittest.skipUnless(os.name == "nt", "Windows fallback only")
+    def test_unusable_py_candidate_falls_back_to_working_python(self):
+        result = self._run()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(self.bad_py_marker.exists())
+        self.assertTrue(_wait_for(self.panel_marker), result.stdout + result.stderr)
+
+
+@unittest.skipUnless(os.name == "nt" and POWERSHELL, "Windows runner only")
+class RunPs1PreflightTest(RunnerIntegrationMixin, unittest.TestCase):
+    runner_name = "run.ps1"
+
+
+@unittest.skipUnless(os.name != "nt", "POSIX runner only")
+class RunShPreflightTest(RunnerIntegrationMixin, unittest.TestCase):
+    runner_name = "run.sh"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stats_facts.mjs
+++ b/tests/test_stats_facts.mjs
@@ -1,0 +1,189 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const source = await readFile(new URL("../web/js/stats-facts.js", import.meta.url), "utf8");
+const facts = await import(`data:text/javascript;base64,${Buffer.from(source).toString("base64")}`);
+let moduleSerial = 0;
+
+async function loadStatsModule() {
+  const coreSource = await readFile(new URL("../web/js/core.js", import.meta.url), "utf8");
+  const coreUrl = `data:text/javascript;base64,${Buffer.from(coreSource).toString("base64")}`;
+  const factsUrl = `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+  const statsSource = (await readFile(new URL("../web/js/stats.js", import.meta.url), "utf8"))
+    .replace('"./core.js"', `"${coreUrl}"`)
+    .replace('"./stats-facts.js"', `"${factsUrl}"`);
+  return import(`data:text/javascript;base64,${Buffer.from(statsSource).toString("base64")}#${++moduleSerial}`);
+}
+
+test("named comparisons use the generated-token English estimate", () => {
+  const catalog = facts.buildTokenFacts(24_800_000);
+  const harry = catalog.find(f => f.id === "book:harry-potter-1");
+  const munich = catalog.find(f => f.id === "route:car:munich-frankfurt");
+
+  assert.equal(harry.amount, 241.7);
+  assert.match(harry.text, /copies of Harry Potter and the Philosopher's Stone/);
+  assert.equal(munich.amount, 423.5);
+  assert.match(munich.text, /Munich–Frankfurt trips by car/);
+  assert.match(munich.assumption, /400 km/);
+});
+
+test("catalog provides a deep pool of concrete references", () => {
+  const catalog = facts.buildTokenFacts(1_000_000);
+  assert.ok(catalog.length >= 100);
+  assert.ok(catalog.some(f => /complete Harry Potter series/.test(f.text)));
+  assert.ok(catalog.some(f => /back-to-back screenings of Titanic/.test(f.text)));
+  assert.ok(catalog.some(f => /Tokyo–Osaka/.test(f.text)));
+  assert.ok(catalog.every(f => f.assumption.includes("0.75 words/token")));
+});
+
+test("fact rotator stays stable between polls and changes after fifteen minutes", () => {
+  const picks = [0, 0, 0.5];
+  const rotate = facts.createFactRotator({ random: () => picks.shift(), intervalMs: 900_000 });
+
+  const first = rotate(1_000_000, 10_000);
+  const polled = rotate(2_000_000, 14_000);
+  const expired = rotate(2_000_000, 910_001);
+
+  assert.equal(polled.id, first.id);
+  assert.notEqual(polled.text, first.text);
+  assert.notEqual(expired.id, first.id);
+});
+
+test("zero generated tokens has a useful empty state", () => {
+  const rotate = facts.createFactRotator({ random: () => 0 });
+  const fact = rotate(0, 0);
+
+  assert.equal(fact.id, "empty");
+  assert.match(fact.text, /Generate some tokens/);
+});
+
+test("small positive totals never rotate to a zero comparison", () => {
+  for (const tokens of [1, 100, 1_000, 10_000]) {
+    const rotate = facts.createFactRotator({ random: () => 0.999 });
+    const fact = rotate(tokens, 0);
+    assert.ok(fact.amount > 0, `${tokens} tokens produced ${fact.text}`);
+    assert.doesNotMatch(fact.text, /^0(?:\.0+)?\s/);
+  }
+});
+
+test("VRAM telemetry is normalized without trusting malformed counters", () => {
+  assert.deepEqual(facts.normalizeVram({gpus: [
+    {index: 0, name: "RTX <5090>", used: 8192, total: 32768, util: 75, temp: 61},
+    {index: 1, name: "broken", used: -2, total: 0},
+  ]}), [{
+    index: 0,
+    name: "RTX <5090>",
+    used: 8192,
+    total: 32768,
+    free: 24576,
+    util: 75,
+    temp: 61,
+  }]);
+  assert.deepEqual(facts.normalizeVram({error: "offline"}), []);
+});
+
+test("compact VRAM cards retain text counters and escape GPU names", async () => {
+  const stats = await loadStatsModule();
+  const markup = stats.renderStatsVram({gpus: [
+    {index: 0, name: "RTX <5090>", used: 8192, total: 32768, util: 75, temp: 61},
+  ]});
+
+  assert.match(markup, /RTX &lt;5090&gt;/);
+  assert.match(markup, /8\.0<\/b>\/32\.0 GB/);
+  assert.match(markup, /FREE <b>24\.0<\/b> GB/);
+  assert.match(markup, /role="progressbar"/);
+  assert.match(markup, /aria-valuenow="8192"/);
+  assert.match(markup, /aria-valuemax="32768"/);
+  assert.match(markup, /aria-valuetext="8\.0 of 32\.0 GB used"/);
+  assert.equal((markup.match(/class="seg/g) || []).length, 28);
+});
+
+test("token scale exposes its full comparison and assumptions to touch and keyboard users", async () => {
+  const stats = await loadStatsModule();
+  const markup = stats.renderTokenScale(24_800_000, {
+    text: "241.7 copies of Harry <Potter>",
+    assumption: "English estimate: 0.75 words/token",
+  });
+
+  assert.match(markup, /<details class="token-scale-details">/);
+  assert.match(markup, /<summary[^>]*>EST\.<\/summary>/);
+  assert.match(markup, /241\.7 copies of Harry &lt;Potter&gt;/);
+  assert.match(markup, /English estimate: 0\.75 words\/token/);
+  assert.match(stats.renderTokenScale(24_800_000, {text: "fact", assumption: "basis"}, true), /<details class="token-scale-details" open>/);
+});
+
+test("a pending GPU probe does not hold back the core Stats view", async () => {
+  const stats = await loadStatsModule();
+  const view = {innerHTML: "", querySelector: () => null};
+  globalThis.document = {querySelector: selector => selector === "#view-stats" ? view : null};
+  globalThis.fetch = path => path === "/api/stats"
+    ? Promise.resolve({json: () => Promise.resolve(statsPayload("FAST"))})
+    : new Promise(() => {});
+
+  await Promise.race([
+    stats.loadStats(false),
+    new Promise((_, reject) => setTimeout(() => reject(new Error("Stats waited for GPU telemetry")), 100)),
+  ]);
+  assert.match(view.innerHTML, /FAST/);
+});
+
+test("an older Stats response cannot overwrite a newer poll", async () => {
+  const stats = await loadStatsModule();
+  const view = {innerHTML: "", querySelector: () => null};
+  globalThis.document = {querySelector: selector => selector === "#view-stats" ? view : null};
+  let resolveOld, resolveNew, calls = 0;
+  globalThis.fetch = path => {
+    if (path === "/api/gpus") return Promise.resolve({json: () => Promise.resolve({gpus: []})});
+    calls += 1;
+    return new Promise(resolve => {
+      const done = label => resolve({json: () => Promise.resolve(statsPayload(label))});
+      if (calls === 1) resolveOld = done; else resolveNew = done;
+    });
+  };
+
+  const oldPoll = stats.loadStats(true);
+  const newPoll = stats.loadStats(true);
+  resolveNew("NEWER");
+  await newPoll;
+  resolveOld("OLDER");
+  await oldPoll;
+  assert.match(view.innerHTML, /NEWER/);
+  assert.doesNotMatch(view.innerHTML, /OLDER/);
+});
+
+test("a polling render restores keyboard focus to the estimate disclosure", async () => {
+  const stats = await loadStatsModule();
+  const oldSummary = {};
+  let rendered = false, focusOptions = null;
+  const newSummary = {focus: options => { focusOptions = options; }};
+  const view = {
+    _html: "",
+    get innerHTML() { return this._html; },
+    set innerHTML(value) { this._html = value; rendered = true; },
+    querySelector: selector => {
+      if (selector === ".token-scale-details") return {open: true};
+      if (selector === ".token-scale-details summary") return rendered ? newSummary : oldSummary;
+      return null;
+    },
+  };
+  globalThis.document = {
+    activeElement: oldSummary,
+    querySelector: selector => selector === "#view-stats" ? view : null,
+  };
+  globalThis.fetch = path => Promise.resolve({json: () => Promise.resolve(
+    path === "/api/stats" ? statsPayload("FOCUSED") : {gpus: []},
+  )});
+
+  await stats.loadStats(true);
+  assert.deepEqual(focusOptions, {preventScroll: true});
+});
+
+function statsPayload(mostUsed) {
+  return {
+    totals: {tokens: 2_000, generated: 1_000, loaded_hours: 1, models_used: 1, total_runs: 2, most_used: mostUsed},
+    live: {router_up: true, loaded_model: "model", gen_per_sec: 1, prompt_per_sec: 2, requests_processing: 0},
+    per_model: [],
+    daily: [],
+  };
+}

--- a/tools/security_ui_smoke.js
+++ b/tools/security_ui_smoke.js
@@ -5,8 +5,7 @@ function check(condition, code) {
 }
 
 async function waitFor(selector, predicate = () => true, code = "missing-selector") {
-  const deadline = Date.now() + 8000;
-  while (Date.now() < deadline) {
+  for (let attempt = 0; attempt < 320; attempt++) {
     const element = document.querySelector(selector);
     if (element && await predicate(element)) return element;
     await new Promise(resolve => setTimeout(resolve, 25));
@@ -15,8 +14,8 @@ async function waitFor(selector, predicate = () => true, code = "missing-selecto
 }
 
 async function waitUntil(predicate, code, timeout = 8000) {
-  const deadline = Date.now() + timeout;
-  while (Date.now() < deadline) {
+  const attempts = Math.ceil(timeout / 25);
+  for (let attempt = 0; attempt < attempts; attempt++) {
     if (await predicate()) return;
     await new Promise(resolve => setTimeout(resolve, 25));
   }
@@ -28,6 +27,16 @@ function click(selector, root = document, code = "missing-click-target") {
   check(element, code);
   element.click();
   return element;
+}
+
+async function closeDialog(dialog, code) {
+  click("[data-mclose]", dialog, code + "-button");
+  await Promise.resolve();
+  // Flush the native close path when Chrome's accelerated headless clock has
+  // queued, but not yet dispatched, the dialog close event.
+  if (dialog.isConnected && dialog.open) dialog.close();
+  if (dialog.isConnected && !dialog.open) dialog.dispatchEvent(new Event("close"));
+  await waitUntil(() => !dialog.isConnected, code);
 }
 
 function hasMinimumPointerTarget(element) {
@@ -51,6 +60,48 @@ async function setScenario(name) {
   check(response.ok && payload.ok, "scenario-selection-failed");
 }
 
+async function setModelScenario(name, expectedBackends) {
+  const stateCount = apiRequests(await requests(), "/api/state", "GET").length;
+  const response = await fetch("/_fixture/models", {
+    method: "POST",
+    headers: {"Content-Type": "application/json"},
+    body: JSON.stringify({name}),
+  });
+  const payload = await response.json();
+  check(response.ok && payload.ok, "model-scenario-selection-failed");
+  await waitUntil(async () => {
+    const list = await requests();
+    if (apiRequests(list, "/api/state", "GET").length <= stateCount) return false;
+    const rows = [...document.querySelectorAll('.row[data-id="shared-fixture"]')];
+    const actual = rows.map(row => row.dataset.backend).sort();
+    return JSON.stringify(actual) === JSON.stringify([...expectedBackends].sort());
+  }, "model-scenario-not-rendered", 12000);
+}
+
+async function delayState() {
+  const response = await fetch("/_fixture/delays", {cache: "no-store"});
+  return response.json();
+}
+
+async function armDelay(kind) {
+  const response = await fetch("/_fixture/delay", {
+    method: "POST",
+    headers: {"Content-Type": "application/json"},
+    body: JSON.stringify({kind, delay_ms: 750}),
+  });
+  const payload = await response.json();
+  check(response.ok && payload.ok, `${kind}-delay-arm-failed`);
+  return (await delayState()).completed[kind];
+}
+
+async function awaitDelayCompletion(kind, completedBefore) {
+  await waitUntil(async () => {
+    const state = await delayState();
+    return state.completed[kind] === completedBefore + 1 &&
+      !state.pending.includes(kind);
+  }, `${kind}-delay-not-completed`);
+}
+
 function apiRequests(list, path, method = null) {
   return list.filter(entry => entry.path === path && (!method || entry.method === method));
 }
@@ -60,19 +111,31 @@ function setValue(element, value) {
   element.dispatchEvent(new Event("change", {bubbles: true}));
 }
 
-function bodyHasSecret() {
-  return document.body.textContent.includes(SENTINEL);
-}
-
-function secretTextIsInside(container) {
-  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
-  let node;
-  while ((node = walker.nextNode())) {
-    if (node.nodeValue.includes(SENTINEL) && !container.contains(node.parentElement)) {
-      return false;
+async function assertSecretState(code, allowedTextRoot = null) {
+  for (const element of document.querySelectorAll("*")) {
+    for (const attribute of element.attributes) {
+      if (attribute.value.includes(SENTINEL)) throw new Error(code);
     }
   }
-  return true;
+  const walker = document.createTreeWalker(
+    document.documentElement, NodeFilter.SHOW_TEXT);
+  let node;
+  while ((node = walker.nextNode())) {
+    if (node.nodeValue.includes(SENTINEL) &&
+        !(allowedTextRoot && allowedTextRoot.contains(node.parentElement))) {
+      throw new Error(code);
+    }
+  }
+  if (location.href.includes(SENTINEL)) throw new Error(code);
+  if (document.cookie.includes(SENTINEL)) throw new Error(code);
+  for (const storage of [localStorage, sessionStorage]) {
+    for (const key of Object.keys(storage)) {
+      if (key.includes(SENTINEL) ||
+          String(storage.getItem(key)).includes(SENTINEL)) throw new Error(code);
+    }
+  }
+  if ((await requests()).some(entry =>
+      JSON.stringify(entry).includes(SENTINEL))) throw new Error(code);
 }
 
 function accessibleName(element) {
@@ -151,12 +214,15 @@ function scrubSecretDom() {
     }
   }
   for (const element of document.querySelectorAll("*")) {
-    for (const attribute of element.attributes) {
+    for (const attribute of [...element.attributes]) {
       if (attribute.value.includes(SENTINEL)) element.removeAttribute(attribute.name);
     }
   }
-  for (const key of Object.keys(localStorage)) {
-    if (String(localStorage.getItem(key)).includes(SENTINEL)) localStorage.removeItem(key);
+  for (const storage of [localStorage, sessionStorage]) {
+    for (const key of Object.keys(storage)) {
+      if (key.includes(SENTINEL) ||
+          String(storage.getItem(key)).includes(SENTINEL)) storage.removeItem(key);
+    }
   }
 }
 
@@ -194,6 +260,20 @@ async function run() {
     "automatic-client-request");
   check(document.querySelector("#network-access"), "missing-network-access");
 
+  const attributeProbe = document.createElement("div");
+  attributeProbe.setAttribute("data-arbitrary-fixture-value", SENTINEL);
+  document.body.append(attributeProbe);
+  let attributeLeakRejected = false;
+  try {
+    await assertSecretState("sentinel-attribute-detected");
+  } catch (error) {
+    attributeLeakRejected = error.message === "sentinel-attribute-detected";
+  } finally {
+    attributeProbe.remove();
+  }
+  check(attributeLeakRejected, "attribute-leak-detector-self-test");
+  await assertSecretState("attribute-probe-not-cleaned");
+
   let root = await renderScenario("local-no-key");
   check(root.querySelector('[name="net-scope"][value="local"]').checked,
     "local-scope-state");
@@ -215,6 +295,23 @@ async function run() {
     "lan-configured-state");
   check(!root.querySelector("#net-runtime").textContent.includes("protected"),
     "listener-policy-conflation");
+  const configuredEndpoint = root.querySelector("#net-configured-endpoint");
+  check(configuredEndpoint, "configured-endpoint-missing");
+  check(configuredEndpoint.textContent.trim() === "http://0.0.0.0:8080/",
+    "configured-endpoint-not-exact");
+  const convenienceUrl = root.querySelector("#net-convenience-url");
+  check(convenienceUrl && convenienceUrl.textContent.trim() ===
+    "http://192.168.1.44:8080/", "lan-convenience-url-missing");
+
+  root = await renderScenario("protected-legacy");
+  check(root.querySelector("#net-configured").textContent.trim() ===
+    "protected legacy", "protected-legacy-configured-state");
+  const advisory = root.querySelector("#net-advisory");
+  check(advisory && advisory.textContent.includes("Rotate this legacy API key"),
+    "protected-legacy-advisory-missing");
+  check(!root.querySelector('#net-alert[role="alert"]') &&
+    advisory.getAttribute("role") !== "alert",
+  "protected-legacy-falsely-remediating");
 
   root = await renderScenario("unsafe-legacy");
   const alert = root.querySelector('#net-alert[role="alert"]');
@@ -258,7 +355,7 @@ async function run() {
     small: "", inject: true,
   }), "agent-preview-request-shape");
   const agentContainer = document.querySelector("#ac-out");
-  check(secretTextIsInside(agentContainer), "agent-secret-outside-preview");
+  await assertSecretState("agent-secret-outside-preview", agentContainer);
   const agentCopy = agentContainer.querySelector(".scopy");
   check(agentCopy && !agentCopy.hasAttribute("data-agent-copy-index"),
     "agent-copy-binding-exposed");
@@ -266,8 +363,8 @@ async function run() {
   await captureSecretCopy(agentCopy, "agent-private-copy");
   injection.checked = false;
   injection.dispatchEvent(new Event("change", {bubbles: true}));
-  check(!document.querySelector("#ac-out .snip") && !bodyHasSecret(),
-    "agent-preview-not-destroyed");
+  check(!document.querySelector("#ac-out .snip"), "agent-preview-not-destroyed");
+  await assertSecretState("agent-secret-after-selector-cleanup");
 
   click('.tab[data-tab="models"]', document, "missing-models-tab");
   const llamaRow = await waitFor('.row[data-id="llama-fixture"]', () => true,
@@ -286,17 +383,15 @@ async function run() {
   check(JSON.stringify(clientPosts.at(-1).body) === JSON.stringify({
     model: "llama-fixture", backend: "llamacpp",
   }), "llama-client-request-shape");
-  check(secretTextIsInside(llamaDialog.closest("dialog")),
-    "client-secret-outside-dialog");
+  await assertSecretState("client-secret-outside-dialog",
+    llamaDialog.closest("dialog"));
   const clientCopy = llamaDialog.closest("dialog").querySelector(".scopy");
   check(clientCopy && !clientCopy.hasAttribute("data-private-copy-index"),
     "client-copy-binding-exposed");
   check(hasMinimumPointerTarget(clientCopy), "client-copy-pointer-target");
   await captureSecretCopy(clientCopy, "client-private-copy");
-  click("[data-mclose]", llamaDialog.closest("dialog"), "missing-client-close");
-  await waitUntil(() => !document.querySelector("#modal-root dialog"),
-    "client-dialog-not-closed");
-  check(!bodyHasSecret(), "client-secret-after-close");
+  await closeDialog(llamaDialog.closest("dialog"), "client-dialog-not-closed");
+  await assertSecretState("client-secret-after-close");
   check(document.activeElement === llamaClient, "client-dialog-focus-return");
 
   const vllmRow = document.querySelector('.row[data-id="vllm-fixture"]');
@@ -308,11 +403,162 @@ async function run() {
   const vllmDialog = await waitFor("#modal-root dialog .snip",
     element => element.textContent.includes("127.0.0.1:8081"),
     "vllm-client-preview-missing");
-  check(!vllmDialog.closest("dialog").textContent.includes(SENTINEL) && !bodyHasSecret(),
+  check(!vllmDialog.closest("dialog").textContent.includes(SENTINEL),
     "vllm-client-secret-leak");
-  click("[data-mclose]", vllmDialog.closest("dialog"), "missing-vllm-close");
-  await waitUntil(() => !document.querySelector("#modal-root dialog"),
-    "vllm-dialog-not-closed");
+  await assertSecretState("vllm-client-secret-state");
+  await closeDialog(vllmDialog.closest("dialog"), "vllm-dialog-not-closed");
+
+  await setModelScenario("shared-llamacpp", ["llamacpp", "vllm"]);
+  const modelSearch = document.querySelector("#model-search");
+  modelSearch.dispatchEvent(new Event("input", {bubbles: true}));
+  let sharedRows = [...document.querySelectorAll('.row[data-id="shared-fixture"]')];
+  check(sharedRows.length === 2, "shared-model-row-count");
+  let sharedVllm = sharedRows.find(row => row.querySelector(".be-vllm"));
+  let sharedLlama = sharedRows.find(row => row.querySelector(".be-llamacpp"));
+  check(sharedVllm?.dataset.backend === "vllm", "shared-vllm-row-ownership");
+  check(sharedLlama?.dataset.backend === "llamacpp", "shared-llama-row-ownership");
+  click(".rhead", sharedVllm, "missing-shared-vllm-row-head");
+  const sharedVllmClient = await waitFor(
+    '.row[data-id="shared-fixture"][data-backend="vllm"] [data-act="client"]',
+    () => true, "missing-shared-vllm-client");
+  const sharedClientBefore = apiRequests(
+    await requests(), "/api/client/config", "POST").length;
+  sharedVllmClient.click();
+  const sharedVllmDialog = await waitFor("#modal-root dialog .snip",
+    element => element.textContent.includes("127.0.0.1:8081"),
+    "shared-vllm-client-preview-missing");
+  const sharedClientPosts = apiRequests(
+    await requests(), "/api/client/config", "POST");
+  check(sharedClientPosts.length === sharedClientBefore + 1,
+    "shared-vllm-client-post-count");
+  check(JSON.stringify(sharedClientPosts.at(-1).body) === JSON.stringify({
+    model: "shared-fixture", backend: "vllm",
+  }), "shared-vllm-client-request-shape");
+  check(!sharedVllmDialog.closest("dialog").textContent.includes(SENTINEL),
+    "shared-vllm-router-secret");
+  await assertSecretState("shared-vllm-secret-state");
+  await closeDialog(sharedVllmDialog.closest("dialog"),
+    "shared-vllm-dialog-not-closed");
+
+  await setModelScenario("shared-ikllama", ["ikllama", "vllm"]);
+  modelSearch.dispatchEvent(new Event("input", {bubbles: true}));
+  sharedRows = [...document.querySelectorAll('.row[data-id="shared-fixture"]')];
+  check(sharedRows.length === 2, "switched-model-row-count");
+  sharedVllm = sharedRows.find(row => row.querySelector(".be-vllm"));
+  const sharedIk = sharedRows.find(row => row.querySelector(".be-ikllama"));
+  check(sharedVllm?.dataset.backend === "vllm", "switched-vllm-row-ownership");
+  check(sharedIk?.dataset.backend === "ikllama", "switched-ik-row-ownership");
+  if (!sharedVllm.classList.contains("open")) {
+    click(".rhead", sharedVllm, "missing-switched-vllm-row-head");
+  }
+  const switchedVllmClient = await waitFor(
+    '.row[data-id="shared-fixture"][data-backend="vllm"] [data-act="client"]',
+    () => true, "missing-switched-vllm-client");
+  const switchedClientBefore = apiRequests(
+    await requests(), "/api/client/config", "POST").length;
+  switchedVllmClient.click();
+  const switchedVllmDialog = await waitFor("#modal-root dialog .snip",
+    element => element.textContent.includes("127.0.0.1:8081"),
+    "switched-vllm-client-preview-missing");
+  const switchedClientPosts = apiRequests(
+    await requests(), "/api/client/config", "POST");
+  check(switchedClientPosts.length === switchedClientBefore + 1 &&
+    JSON.stringify(switchedClientPosts.at(-1).body) === JSON.stringify({
+      model: "shared-fixture", backend: "vllm",
+    }), "switched-vllm-client-request-shape");
+  check(!switchedVllmDialog.closest("dialog").textContent.includes(SENTINEL),
+    "switched-vllm-router-secret");
+  await assertSecretState("switched-vllm-secret-state");
+  await closeDialog(switchedVllmDialog.closest("dialog"),
+    "switched-vllm-dialog-not-closed");
+
+  await setModelScenario("default", []);
+  await waitUntil(() => document.querySelector('.row[data-id="llama-fixture"]') &&
+    document.querySelector('.row[data-id="vllm-fixture"]'),
+  "default-models-not-restored", 12000);
+
+  const delayedLlamaRow = document.querySelector('.row[data-id="llama-fixture"]');
+  click(".rhead", delayedLlamaRow, "missing-delayed-client-row-head");
+  const delayedClientButton = await waitFor(
+    '.row[data-id="llama-fixture"].open [data-act="client"]', () => true,
+    "missing-delayed-client-action");
+  const clientCompleted = await armDelay("client");
+  const delayedClientBefore = apiRequests(
+    await requests(), "/api/client/config", "POST").length;
+  delayedClientButton.click();
+  const pendingClientDialog = await waitFor("#modal-root dialog",
+    dialog => dialog.textContent.includes("Generating configuration"),
+    "delayed-client-pending-dialog-missing");
+  await waitUntil(async () => apiRequests(
+    await requests(), "/api/client/config", "POST").length === delayedClientBefore + 1,
+  "delayed-client-request-missing");
+  await closeDialog(pendingClientDialog, "delayed-client-dialog-not-closed");
+  click('.tab[data-tab="setup"]', document, "missing-setup-tab");
+  await awaitDelayCompletion("client", clientCompleted);
+  await waitFor("#agent-connect #ac-show",
+    element => typeof element.onclick === "function", "setup-after-delayed-client-missing");
+  check(!document.querySelector("#modal-root dialog"),
+    "delayed-client-response-reopened-dialog");
+  await assertSecretState("delayed-client-secret-installed");
+
+  let delayedAgent = document.querySelector("#ac-agent");
+  setValue(delayedAgent, "codex");
+  let delayedInjection = document.querySelector("#ac-inject");
+  delayedInjection.checked = true;
+  delayedInjection.dispatchEvent(new Event("change", {bubbles: true}));
+  setValue(document.querySelector("#ac-model"), "llama-fixture");
+  const agentCompleted = await armDelay("agent");
+  const delayedAgentBefore = apiRequests(
+    await requests(), "/api/agent/config", "POST").length;
+  click("#ac-show", document, "missing-delayed-agent-show");
+  await waitFor("#ac-out [role=\"status\"]",
+    element => element.textContent.includes("Generating configuration"),
+    "delayed-agent-pending-state-missing");
+  await waitUntil(async () => apiRequests(
+    await requests(), "/api/agent/config", "POST").length === delayedAgentBefore + 1,
+  "delayed-agent-request-missing");
+  click('.tab[data-tab="models"]', document, "missing-models-tab");
+  await awaitDelayCompletion("agent", agentCompleted);
+  await new Promise(resolve => setTimeout(resolve, 25));
+  check(!document.querySelector("#ac-out .snip"),
+    "delayed-agent-response-installed");
+  await assertSecretState("delayed-agent-secret-installed");
+
+  root = await renderScenario("local-no-key");
+  delayedAgent = document.querySelector("#ac-agent");
+  setValue(delayedAgent, "codex");
+  delayedInjection = document.querySelector("#ac-inject");
+  delayedInjection.checked = true;
+  delayedInjection.dispatchEvent(new Event("change", {bubbles: true}));
+  setValue(document.querySelector("#ac-model"), "llama-fixture");
+  click("#ac-show", document, "missing-visible-agent-show");
+  const visibleAgentPreview = await waitFor("#ac-out .snip",
+    element => element.textContent.includes(SENTINEL),
+    "visible-agent-preview-missing");
+  const visibleAgentCopy = visibleAgentPreview.querySelector(".scopy");
+  click('.tab[data-tab="models"]', document, "missing-models-tab");
+  check(!document.querySelector("#ac-out .snip"),
+    "visible-agent-preview-after-navigation");
+  check(visibleAgentCopy.onclick === null,
+    "visible-agent-copy-live-after-navigation");
+  await assertSecretState("visible-agent-secret-after-navigation");
+
+  root = await renderScenario("local-no-key");
+  const networkCompleted = await armDelay("network");
+  const delayedNetworkBefore = apiRequests(
+    await requests(), "/api/network", "POST").length;
+  click('[name="net-key-action"][value="generate"]', root,
+    "missing-delayed-network-generate");
+  click("#net-apply", root, "missing-delayed-network-apply");
+  await waitUntil(async () => apiRequests(
+    await requests(), "/api/network", "POST").length === delayedNetworkBefore + 1,
+  "delayed-network-request-missing");
+  click('.tab[data-tab="models"]', document, "missing-models-tab");
+  await awaitDelayCompletion("network", networkCompleted);
+  await new Promise(resolve => setTimeout(resolve, 25));
+  check(root.querySelector("#net-generated").hidden,
+    "delayed-network-secret-panel-installed");
+  await assertSecretState("delayed-network-secret-installed");
 
   const generateSecretPanel = async () => {
     const networkRoot = await renderScenario("local-no-key");
@@ -324,7 +570,7 @@ async function run() {
       "generated-panel-missing");
     const display = panel.querySelector("#net-generated-display");
     check(display.textContent === "••••••••••••••••", "generated-not-masked");
-    check(!bodyHasSecret(), "generated-secret-rendered-without-reveal");
+    await assertSecretState("generated-secret-rendered-without-reveal");
     await waitUntil(() => !networkRoot.querySelector("#net-apply").disabled,
       "network-apply-not-restored");
     const posts = apiRequests(await requests(), "/api/network", "POST");
@@ -341,16 +587,16 @@ async function run() {
   "generated-copy-pointer-target");
   await captureSecretCopy(generated.panel.querySelector("#net-copy-generated"),
     "generated-private-copy", true);
-  check(!bodyHasSecret(), "generated-copy-rendered-secret");
+  await assertSecretState("generated-copy-rendered-secret");
   click("#net-reveal-generated", generated.panel, "missing-generated-reveal");
   await waitUntil(() => generated.display.textContent === SENTINEL,
     "generated-reveal-missing");
-  check(secretTextIsInside(generated.display), "generated-secret-outside-display");
+  await assertSecretState("generated-secret-outside-display", generated.display);
   await waitUntil(() => {
     const reveal = generated.panel.querySelector("#net-reveal-generated");
     return reveal.disabled && generated.display.getAttribute("aria-label")?.includes("expired");
   }, "generated-secret-did-not-expire", 35000);
-  check(!bodyHasSecret(), "generated-secret-after-expiry");
+  await assertSecretState("generated-secret-after-expiry");
   check(generated.panel.querySelector("#net-copy-generated").disabled,
     "generated-copy-active-after-expiry");
   clipboardValue = "";
@@ -364,7 +610,7 @@ async function run() {
   const retryDialog = await waitFor("#net-confirm", element => element.open,
     "retry-confirm-missing");
   await waitUntil(() => retryCopy.onclick === null, "retry-secret-not-cleared");
-  check(!bodyHasSecret(), "retry-secret-in-dom");
+  await assertSecretState("retry-secret-after-cleanup");
   retryDialog.dispatchEvent(new Event("cancel", {cancelable: true}));
   await waitUntil(() => !document.querySelector("#net-confirm"),
     "retry-confirm-not-cancelled");
@@ -372,13 +618,18 @@ async function run() {
   generated = await generateSecretPanel();
   const doneCopy = generated.panel.querySelector("#net-copy-generated");
   click("#net-dismiss-generated", generated.panel, "missing-generated-done");
-  check(doneCopy.onclick === null && !bodyHasSecret(), "done-secret-not-cleared");
+  check(doneCopy.onclick === null, "done-secret-not-cleared");
+  await assertSecretState("done-secret-after-cleanup");
 
   generated = await generateSecretPanel();
   const navCopy = generated.panel.querySelector("#net-copy-generated");
+  click("#net-reveal-generated", generated.panel,
+    "missing-navigation-generated-reveal");
+  await waitUntil(() => generated.display.textContent === SENTINEL,
+    "navigation-generated-reveal-missing");
   click('.tab[data-tab="models"]', document, "missing-models-tab");
   await waitUntil(() => navCopy.onclick === null, "navigation-secret-not-cleared");
-  check(!bodyHasSecret(), "navigation-secret-in-dom");
+  await assertSecretState("navigation-secret-after-cleanup");
 
   generated = await generateSecretPanel();
   const rerenderCopy = generated.panel.querySelector("#net-copy-generated");
@@ -387,7 +638,7 @@ async function run() {
   await waitFor("#network-access", element => element !== oldNetworkRoot,
     "setup-rerender-missing");
   await waitUntil(() => rerenderCopy.onclick === null, "rerender-secret-not-cleared");
-  check(!bodyHasSecret(), "rerender-secret-in-dom");
+  await assertSecretState("rerender-secret-after-cleanup");
 
   root = await renderScenario("local-keyed");
   click('[name="net-key-action"][value="generate"]', root,
@@ -479,19 +730,18 @@ async function run() {
   document.documentElement.dataset.theme = "dark";
   delete document.documentElement.dataset.cvd;
 
-  check([...document.querySelectorAll('[role="status"], [role="alert"], #toast')]
-    .every(element => !element.textContent.includes(SENTINEL)),
-  "secret-in-live-region");
-  check(!location.href.includes(SENTINEL), "secret-in-url");
-  check(Object.keys(localStorage).every(
-    key => !String(localStorage.getItem(key)).includes(SENTINEL)),
-  "secret-in-local-storage");
-  check((await requests()).every(entry =>
-    !JSON.stringify(entry.body).includes(SENTINEL)), "secret-in-operation-log");
-  check(!bodyHasSecret(), "secret-in-final-dom");
+  await assertSecretState("secret-in-final-state");
 }
 
-function finish(status, code) {
+async function finish(status, code) {
+  try {
+    await assertSecretState("secret-before-final-scrub");
+  } catch (error) {
+    if (status === "pass") {
+      status = "fail";
+      code = error.message;
+    }
+  }
   scrubSecretDom();
   const result = document.createElement("pre");
   result.id = "lf-security-result";

--- a/tools/security_ui_smoke.js
+++ b/tools/security_ui_smoke.js
@@ -1,0 +1,510 @@
+const SENTINEL = "fixture-secret-must-not-leak-" + "f".repeat(16);
+
+function check(condition, code) {
+  if (!condition) throw new Error(code);
+}
+
+async function waitFor(selector, predicate = () => true, code = "missing-selector") {
+  const deadline = Date.now() + 8000;
+  while (Date.now() < deadline) {
+    const element = document.querySelector(selector);
+    if (element && await predicate(element)) return element;
+    await new Promise(resolve => setTimeout(resolve, 25));
+  }
+  throw new Error(code);
+}
+
+async function waitUntil(predicate, code, timeout = 8000) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise(resolve => setTimeout(resolve, 25));
+  }
+  throw new Error(code);
+}
+
+function click(selector, root = document, code = "missing-click-target") {
+  const element = root.querySelector(selector);
+  check(element, code);
+  element.click();
+  return element;
+}
+
+function hasMinimumPointerTarget(element) {
+  const rect = element.getBoundingClientRect();
+  return rect.width >= 48 && rect.height >= 48;
+}
+
+async function requests() {
+  const response = await fetch("/_fixture/requests", {cache: "no-store"});
+  const payload = await response.json();
+  return payload.requests;
+}
+
+async function setScenario(name) {
+  const response = await fetch("/_fixture/scenario", {
+    method: "POST",
+    headers: {"Content-Type": "application/json"},
+    body: JSON.stringify({name}),
+  });
+  const payload = await response.json();
+  check(response.ok && payload.ok, "scenario-selection-failed");
+}
+
+function apiRequests(list, path, method = null) {
+  return list.filter(entry => entry.path === path && (!method || entry.method === method));
+}
+
+function setValue(element, value) {
+  element.value = value;
+  element.dispatchEvent(new Event("change", {bubbles: true}));
+}
+
+function bodyHasSecret() {
+  return document.body.textContent.includes(SENTINEL);
+}
+
+function secretTextIsInside(container) {
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+  let node;
+  while ((node = walker.nextNode())) {
+    if (node.nodeValue.includes(SENTINEL) && !container.contains(node.parentElement)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function accessibleName(element) {
+  const labelled = element.getAttribute("aria-labelledby");
+  if (labelled) {
+    return labelled.split(/\s+/).map(id => document.getElementById(id)?.textContent || "")
+      .join(" ").trim();
+  }
+  return (element.getAttribute("aria-label") || element.textContent || "").trim();
+}
+
+function dispatchTab(element, shiftKey) {
+  element.dispatchEvent(new KeyboardEvent("keydown", {
+    key: "Tab", shiftKey, bubbles: true, cancelable: true,
+  }));
+}
+
+function parseRgb(value) {
+  const match = value.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+  return match ? match.slice(1, 4).map(Number) : null;
+}
+
+function luminance(rgb) {
+  const values = rgb.map(value => {
+    const normalized = value / 255;
+    return normalized <= 0.03928
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4;
+  });
+  return values[0] * 0.2126 + values[1] * 0.7152 + values[2] * 0.0722;
+}
+
+function contrastRatio(element) {
+  const foreground = parseRgb(getComputedStyle(element).color);
+  let current = element;
+  let background = null;
+  while (current && !background) {
+    const color = getComputedStyle(current).backgroundColor;
+    if (color && color !== "transparent" && !color.endsWith(", 0)")) {
+      background = parseRgb(color);
+    }
+    current = current.parentElement;
+  }
+  background ||= parseRgb(getComputedStyle(document.body).backgroundColor);
+  if (!foreground || !background) return 0;
+  const a = luminance(foreground);
+  const b = luminance(background);
+  return (Math.max(a, b) + 0.05) / (Math.min(a, b) + 0.05);
+}
+
+function hasLabel(control) {
+  return Boolean(control.closest("label") || control.getAttribute("aria-label") ||
+    control.getAttribute("aria-labelledby") ||
+    (control.id && document.querySelector(`label[for="${CSS.escape(control.id)}"]`)));
+}
+
+async function renderScenario(name) {
+  await setScenario(name);
+  const previous = document.querySelector("#network-access");
+  click('.tab[data-tab="setup"]', document, "missing-setup-tab");
+  return waitFor("#network-access", element => element !== previous,
+    "missing-network-access");
+}
+
+function scrubSecretDom() {
+  document.querySelector("#modal-root")?.replaceChildren();
+  document.querySelector("#ac-out")?.replaceChildren();
+  for (const element of document.querySelectorAll("#net-generated-display")) {
+    element.textContent = "";
+  }
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+  let node;
+  while ((node = walker.nextNode())) {
+    if (node.nodeValue.includes(SENTINEL)) {
+      node.nodeValue = node.nodeValue.replaceAll(SENTINEL, "[fixture secret redacted]");
+    }
+  }
+  for (const element of document.querySelectorAll("*")) {
+    for (const attribute of element.attributes) {
+      if (attribute.value.includes(SENTINEL)) element.removeAttribute(attribute.name);
+    }
+  }
+  for (const key of Object.keys(localStorage)) {
+    if (String(localStorage.getItem(key)).includes(SENTINEL)) localStorage.removeItem(key);
+  }
+}
+
+async function run() {
+  let clipboardValue = "";
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: {
+      writeText(value) {
+        clipboardValue = String(value);
+        return Promise.resolve();
+      },
+    },
+  });
+
+  const captureSecretCopy = async (button, code, exact = false) => {
+    clipboardValue = "";
+    button.click();
+    await waitUntil(() => clipboardValue !== "", code);
+    check(exact ? clipboardValue === SENTINEL : clipboardValue.includes(SENTINEL), code);
+    clipboardValue = "";
+  };
+
+  await waitFor("#agent-connect #ac-apply",
+    element => typeof element.onclick === "function", "agent-controls-not-wired");
+  await waitFor("#ac-out .note", () => true, "agent-initial-state-missing");
+  await waitUntil(async () => {
+    const list = await requests();
+    return apiRequests(list, "/api/network", "GET").length > 0;
+  }, "setup-network-request-missing");
+  const routine = await requests();
+  check(apiRequests(routine, "/api/agent/config").length === 0,
+    "automatic-agent-request");
+  check(apiRequests(routine, "/api/client/config").length === 0,
+    "automatic-client-request");
+  check(document.querySelector("#network-access"), "missing-network-access");
+
+  let root = await renderScenario("local-no-key");
+  check(root.querySelector('[name="net-scope"][value="local"]').checked,
+    "local-scope-state");
+  check(root.querySelector("#net-configured").textContent.trim() === "local",
+    "local-configured-state");
+  check(root.querySelector("#net-runtime").textContent.includes("listening"),
+    "local-listener-state");
+
+  root = await renderScenario("local-keyed");
+  check(root.querySelector("#net-configured").textContent.trim() === "local keyed",
+    "local-keyed-configured-state");
+  check(!root.querySelector('[name="net-key-action"][value="keep"]').disabled,
+    "local-keyed-keep-state");
+
+  root = await renderScenario("lan-protected");
+  check(root.querySelector('[name="net-scope"][value="lan"]').checked,
+    "lan-scope-state");
+  check(root.querySelector("#net-configured").textContent.trim() === "protected",
+    "lan-configured-state");
+  check(!root.querySelector("#net-runtime").textContent.includes("protected"),
+    "listener-policy-conflation");
+
+  root = await renderScenario("unsafe-legacy");
+  const alert = root.querySelector('#net-alert[role="alert"]');
+  check(alert && alert.textContent.includes("cannot be verified"),
+    "unsafe-legacy-alert");
+  check(root.querySelector("#net-configured").textContent.trim() === "unsafe legacy",
+    "unsafe-legacy-configured-state");
+
+  root = await renderScenario("local-no-key");
+  click('[name="net-scope"][value="lan"]', root, "missing-lan-radio");
+  click('[name="net-key-action"][value="replace"]', root,
+    "missing-replace-radio");
+  const replacement = root.querySelector("#net-replace-key");
+  replacement.value = "";
+  const beforeBlank = apiRequests(await requests(), "/api/network", "POST").length;
+  click("#net-apply", root, "missing-network-apply");
+  await waitFor("#net-apply-error", element => !element.hidden,
+    "blank-replacement-error-missing");
+  check(document.activeElement === replacement, "blank-replacement-focus");
+  check(replacement.getAttribute("aria-invalid") === "true",
+    "blank-replacement-invalid-state");
+  check(apiRequests(await requests(), "/api/network", "POST").length === beforeBlank,
+    "blank-replacement-posted");
+
+  const beforeSelectors = apiRequests(await requests(), "/api/agent/config").length;
+  const agent = document.querySelector("#ac-agent");
+  setValue(agent, "codex");
+  const injection = document.querySelector("#ac-inject");
+  injection.checked = true;
+  injection.dispatchEvent(new Event("change", {bubbles: true}));
+  setValue(document.querySelector("#ac-model"), "llama-fixture");
+  check(apiRequests(await requests(), "/api/agent/config").length === beforeSelectors,
+    "selector-triggered-agent-request");
+  click("#ac-show", document, "missing-agent-show");
+  const agentOut = await waitFor("#ac-out .snip",
+    element => element.textContent.includes(SENTINEL), "agent-preview-missing");
+  const agentPosts = apiRequests(await requests(), "/api/agent/config", "POST");
+  check(agentPosts.length === beforeSelectors + 1, "agent-preview-post-count");
+  check(JSON.stringify(agentPosts.at(-1).body) === JSON.stringify({
+    agent: "codex", model: "llama-fixture", backend: "llamacpp",
+    small: "", inject: true,
+  }), "agent-preview-request-shape");
+  const agentContainer = document.querySelector("#ac-out");
+  check(secretTextIsInside(agentContainer), "agent-secret-outside-preview");
+  const agentCopy = agentContainer.querySelector(".scopy");
+  check(agentCopy && !agentCopy.hasAttribute("data-agent-copy-index"),
+    "agent-copy-binding-exposed");
+  check(hasMinimumPointerTarget(agentCopy), "agent-copy-pointer-target");
+  await captureSecretCopy(agentCopy, "agent-private-copy");
+  injection.checked = false;
+  injection.dispatchEvent(new Event("change", {bubbles: true}));
+  check(!document.querySelector("#ac-out .snip") && !bodyHasSecret(),
+    "agent-preview-not-destroyed");
+
+  click('.tab[data-tab="models"]', document, "missing-models-tab");
+  const llamaRow = await waitFor('.row[data-id="llama-fixture"]', () => true,
+    "missing-llama-row");
+  click(".rhead", llamaRow, "missing-llama-row-head");
+  const llamaClient = await waitFor(
+    '.row[data-id="llama-fixture"].open [data-act="client"]', () => true,
+    "missing-llama-client-action");
+  const clientBefore = apiRequests(await requests(), "/api/client/config", "POST").length;
+  llamaClient.focus();
+  llamaClient.click();
+  const llamaDialog = await waitFor("#modal-root dialog .snip",
+    element => element.textContent.includes(SENTINEL), "llama-client-preview-missing");
+  const clientPosts = apiRequests(await requests(), "/api/client/config", "POST");
+  check(clientPosts.length === clientBefore + 1, "llama-client-post-count");
+  check(JSON.stringify(clientPosts.at(-1).body) === JSON.stringify({
+    model: "llama-fixture", backend: "llamacpp",
+  }), "llama-client-request-shape");
+  check(secretTextIsInside(llamaDialog.closest("dialog")),
+    "client-secret-outside-dialog");
+  const clientCopy = llamaDialog.closest("dialog").querySelector(".scopy");
+  check(clientCopy && !clientCopy.hasAttribute("data-private-copy-index"),
+    "client-copy-binding-exposed");
+  check(hasMinimumPointerTarget(clientCopy), "client-copy-pointer-target");
+  await captureSecretCopy(clientCopy, "client-private-copy");
+  click("[data-mclose]", llamaDialog.closest("dialog"), "missing-client-close");
+  await waitUntil(() => !document.querySelector("#modal-root dialog"),
+    "client-dialog-not-closed");
+  check(!bodyHasSecret(), "client-secret-after-close");
+  check(document.activeElement === llamaClient, "client-dialog-focus-return");
+
+  const vllmRow = document.querySelector('.row[data-id="vllm-fixture"]');
+  click(".rhead", vllmRow, "missing-vllm-row-head");
+  const vllmClient = await waitFor(
+    '.row[data-id="vllm-fixture"].open [data-act="client"]', () => true,
+    "missing-vllm-client-action");
+  vllmClient.click();
+  const vllmDialog = await waitFor("#modal-root dialog .snip",
+    element => element.textContent.includes("127.0.0.1:8081"),
+    "vllm-client-preview-missing");
+  check(!vllmDialog.closest("dialog").textContent.includes(SENTINEL) && !bodyHasSecret(),
+    "vllm-client-secret-leak");
+  click("[data-mclose]", vllmDialog.closest("dialog"), "missing-vllm-close");
+  await waitUntil(() => !document.querySelector("#modal-root dialog"),
+    "vllm-dialog-not-closed");
+
+  const generateSecretPanel = async () => {
+    const networkRoot = await renderScenario("local-no-key");
+    const postCount = apiRequests(await requests(), "/api/network", "POST").length;
+    click('[name="net-key-action"][value="generate"]', networkRoot,
+      "missing-generate-action");
+    click("#net-apply", networkRoot, "missing-generate-apply");
+    const panel = await waitFor("#net-generated", element => !element.hidden,
+      "generated-panel-missing");
+    const display = panel.querySelector("#net-generated-display");
+    check(display.textContent === "••••••••••••••••", "generated-not-masked");
+    check(!bodyHasSecret(), "generated-secret-rendered-without-reveal");
+    await waitUntil(() => !networkRoot.querySelector("#net-apply").disabled,
+      "network-apply-not-restored");
+    const posts = apiRequests(await requests(), "/api/network", "POST");
+    check(posts.length === postCount + 1, "generate-post-count");
+    check(JSON.stringify(posts.at(-1).body) === JSON.stringify({
+      access_scope: "local", key_action: "generate",
+    }), "generate-request-shape");
+    return {root: networkRoot, panel, display};
+  };
+
+  let generated = await generateSecretPanel();
+  check(hasMinimumPointerTarget(
+    generated.panel.querySelector("#net-copy-generated")),
+  "generated-copy-pointer-target");
+  await captureSecretCopy(generated.panel.querySelector("#net-copy-generated"),
+    "generated-private-copy", true);
+  check(!bodyHasSecret(), "generated-copy-rendered-secret");
+  click("#net-reveal-generated", generated.panel, "missing-generated-reveal");
+  await waitUntil(() => generated.display.textContent === SENTINEL,
+    "generated-reveal-missing");
+  check(secretTextIsInside(generated.display), "generated-secret-outside-display");
+  await waitUntil(() => {
+    const reveal = generated.panel.querySelector("#net-reveal-generated");
+    return reveal.disabled && generated.display.getAttribute("aria-label")?.includes("expired");
+  }, "generated-secret-did-not-expire", 35000);
+  check(!bodyHasSecret(), "generated-secret-after-expiry");
+  check(generated.panel.querySelector("#net-copy-generated").disabled,
+    "generated-copy-active-after-expiry");
+  clipboardValue = "";
+  generated.panel.querySelector("#net-copy-generated").click();
+  await Promise.resolve();
+  check(clipboardValue === "", "generated-closure-live-after-expiry");
+
+  generated = await generateSecretPanel();
+  const retryCopy = generated.panel.querySelector("#net-copy-generated");
+  click("#net-apply", generated.root, "missing-retry-apply");
+  const retryDialog = await waitFor("#net-confirm", element => element.open,
+    "retry-confirm-missing");
+  await waitUntil(() => retryCopy.onclick === null, "retry-secret-not-cleared");
+  check(!bodyHasSecret(), "retry-secret-in-dom");
+  retryDialog.dispatchEvent(new Event("cancel", {cancelable: true}));
+  await waitUntil(() => !document.querySelector("#net-confirm"),
+    "retry-confirm-not-cancelled");
+
+  generated = await generateSecretPanel();
+  const doneCopy = generated.panel.querySelector("#net-copy-generated");
+  click("#net-dismiss-generated", generated.panel, "missing-generated-done");
+  check(doneCopy.onclick === null && !bodyHasSecret(), "done-secret-not-cleared");
+
+  generated = await generateSecretPanel();
+  const navCopy = generated.panel.querySelector("#net-copy-generated");
+  click('.tab[data-tab="models"]', document, "missing-models-tab");
+  await waitUntil(() => navCopy.onclick === null, "navigation-secret-not-cleared");
+  check(!bodyHasSecret(), "navigation-secret-in-dom");
+
+  generated = await generateSecretPanel();
+  const rerenderCopy = generated.panel.querySelector("#net-copy-generated");
+  const oldNetworkRoot = generated.root;
+  click('.tab[data-tab="setup"]', document, "missing-setup-tab");
+  await waitFor("#network-access", element => element !== oldNetworkRoot,
+    "setup-rerender-missing");
+  await waitUntil(() => rerenderCopy.onclick === null, "rerender-secret-not-cleared");
+  check(!bodyHasSecret(), "rerender-secret-in-dom");
+
+  root = await renderScenario("local-keyed");
+  click('[name="net-key-action"][value="generate"]', root,
+    "missing-rotate-action");
+  const rotateApply = root.querySelector("#net-apply");
+  const rotatePostCount = apiRequests(await requests(), "/api/network", "POST").length;
+  rotateApply.focus();
+  rotateApply.click();
+  let confirm = await waitFor("#net-confirm", element => element.open,
+    "rotate-confirm-missing");
+  check(accessibleName(confirm) === "Rotate router API key",
+    "rotate-confirm-name");
+  let cancel = confirm.querySelector("#net-confirm-cancel");
+  let accept = confirm.querySelector("#net-confirm-accept");
+  check(document.activeElement === cancel, "rotate-cancel-initial-focus");
+  check(hasMinimumPointerTarget(cancel), "dialog-cancel-pointer-target");
+  check(apiRequests(await requests(), "/api/network", "POST").length === rotatePostCount,
+    "rotate-post-before-confirm");
+  dispatchTab(cancel, true);
+  check(document.activeElement === accept, "dialog-shift-tab-trap");
+  dispatchTab(accept, false);
+  check(document.activeElement === cancel, "dialog-tab-trap");
+  confirm.dispatchEvent(new Event("cancel", {cancelable: true}));
+  await waitUntil(() => !document.querySelector("#net-confirm"),
+    "rotate-escape-cancel");
+  check(document.activeElement === rotateApply, "rotate-focus-return");
+
+  root = await renderScenario("local-keyed");
+  click('[name="net-key-action"][value="clear"]', root,
+    "missing-clear-action");
+  const clearApply = root.querySelector("#net-apply");
+  const clearPostCount = apiRequests(await requests(), "/api/network", "POST").length;
+  clearApply.focus();
+  clearApply.click();
+  confirm = await waitFor("#net-confirm", element => element.open,
+    "clear-confirm-missing");
+  check(accessibleName(confirm) === "Remove router API key", "clear-confirm-name");
+  cancel = confirm.querySelector("#net-confirm-cancel");
+  check(document.activeElement === cancel, "clear-cancel-initial-focus");
+  check(apiRequests(await requests(), "/api/network", "POST").length === clearPostCount,
+    "clear-post-before-confirm");
+  cancel.click();
+  await waitUntil(() => !document.querySelector("#net-confirm"),
+    "clear-confirm-not-cancelled");
+  check(document.activeElement === clearApply, "clear-focus-return");
+
+  root = await renderScenario("forced-restart-failure");
+  click('[name="net-scope"][value="lan"]', root, "missing-failure-lan-action");
+  click("#net-apply", root, "missing-failure-apply");
+  const failure = await waitFor("#net-apply-error", element => !element.hidden,
+    "restart-failure-message-missing");
+  const failureText = failure.textContent.toLowerCase();
+  const observedText = root.querySelector("#net-runtime").textContent.toLowerCase();
+  check(failureText.includes("saved") && failureText.includes("restart failed") &&
+    failureText.includes("not verified"), "restart-failure-wording");
+  check(!observedText.includes("protected") && !observedText.includes("running") &&
+    observedText.includes("not verified"), "restart-observation-overclaim");
+
+  root = document.querySelector("#network-access");
+  check(root.querySelectorAll("fieldset").length === 2 &&
+    [...root.querySelectorAll("fieldset")].every(fieldset => fieldset.querySelector("legend")),
+  "network-fieldset-legend");
+  check([...root.querySelectorAll("input, select, textarea")].every(hasLabel),
+    "network-orphaned-control");
+  const described = root.querySelector("#net-replace-key").getAttribute("aria-describedby") || "";
+  check(described.includes("net-replace-help") && described.includes("net-apply-error"),
+    "network-help-association");
+  for (const label of root.querySelectorAll('fieldset > label')) {
+    check(hasMinimumPointerTarget(label), "radio-pointer-target");
+  }
+  for (const button of [root.querySelector("#net-apply")]) {
+    check(hasMinimumPointerTarget(button), "button-pointer-target");
+  }
+
+  for (const theme of ["dark", "light"]) {
+    for (const cvd of [false, true]) {
+      document.documentElement.dataset.theme = theme;
+      if (cvd) document.documentElement.dataset.cvd = "safe";
+      else delete document.documentElement.dataset.cvd;
+      for (const element of [
+        root.querySelector("#network-title"),
+        root.querySelector("#net-configured"),
+        root.querySelector('#net-scope-group > label'),
+      ]) {
+        check(contrastRatio(element) >= 4.5, "network-color-contrast");
+      }
+    }
+  }
+  document.documentElement.dataset.theme = "dark";
+  delete document.documentElement.dataset.cvd;
+
+  check([...document.querySelectorAll('[role="status"], [role="alert"], #toast')]
+    .every(element => !element.textContent.includes(SENTINEL)),
+  "secret-in-live-region");
+  check(!location.href.includes(SENTINEL), "secret-in-url");
+  check(Object.keys(localStorage).every(
+    key => !String(localStorage.getItem(key)).includes(SENTINEL)),
+  "secret-in-local-storage");
+  check((await requests()).every(entry =>
+    !JSON.stringify(entry.body).includes(SENTINEL)), "secret-in-operation-log");
+  check(!bodyHasSecret(), "secret-in-final-dom");
+}
+
+function finish(status, code) {
+  scrubSecretDom();
+  const result = document.createElement("pre");
+  result.id = "lf-security-result";
+  result.dataset.status = status;
+  result.textContent = status === "pass" ? "PASS" : code;
+  document.body.append(result);
+}
+
+run().then(
+  () => finish("pass", "PASS"),
+  error => {
+    const code = /^[a-z0-9-]+$/.test(String(error?.message || ""))
+      ? error.message : "unexpected-fixture-failure";
+    finish("fail", code);
+  },
+);

--- a/tools/security_ui_smoke.py
+++ b/tools/security_ui_smoke.py
@@ -38,7 +38,7 @@ PUBLIC_CONFIG = {
     "active_engine": "llamacpp",
     "router_api_key_configured": False,
 }
-MODELS = [
+DEFAULT_MODELS = [
     {"id": "llama-fixture", "backend": "llamacpp", "status": "loaded",
      "settings": {}, "modalities": ["text"], "in_ini": True,
      "endpoint": "http://127.0.0.1:8080", "eff_ctx": 4096},
@@ -46,6 +46,27 @@ MODELS = [
      "settings": {}, "modalities": ["text"], "in_ini": True,
      "endpoint": "http://127.0.0.1:8081", "eff_ctx": 4096},
 ]
+MODEL_SCENARIOS = {
+    "default": (DEFAULT_MODELS, "llamacpp"),
+    # Deliberately put vLLM first. State rows are not specified to be ordered
+    # by backend, and this catches DOM reconciliation that keys only on id.
+    "shared-llamacpp": ([
+        {"id": "shared-fixture", "backend": "vllm", "status": "loaded",
+         "settings": {}, "modalities": ["text"], "in_ini": True,
+         "endpoint": "http://127.0.0.1:8081", "eff_ctx": 4096},
+        {"id": "shared-fixture", "backend": "llamacpp", "status": "loaded",
+         "settings": {}, "modalities": ["text"], "in_ini": True,
+         "endpoint": "http://127.0.0.1:8080", "eff_ctx": 4096},
+    ], "llamacpp"),
+    "shared-ikllama": ([
+        {"id": "shared-fixture", "backend": "vllm", "status": "loaded",
+         "settings": {}, "modalities": ["text"], "in_ini": True,
+         "endpoint": "http://127.0.0.1:8081", "eff_ctx": 4096},
+        {"id": "shared-fixture", "backend": "ikllama", "status": "loaded",
+         "settings": {}, "modalities": ["text"], "in_ini": True,
+         "endpoint": "http://127.0.0.1:8080", "eff_ctx": 4096},
+    ], "ikllama"),
+}
 LOCAL_NETWORK = {
     "access_scope": "local", "host": "127.0.0.1", "port": 8080,
     "lan_ip": "192.168.1.44", "router_running": True,
@@ -66,6 +87,13 @@ SCENARIOS = {
         "access_scope": "lan", "host": "0.0.0.0",
         "configured_security_status": "protected",
         "key_status": "strong", "has_api_key": True,
+    },
+    "protected-legacy": {
+        **LOCAL_NETWORK,
+        "access_scope": "lan", "host": "0.0.0.0",
+        "configured_security_status": "protected_legacy",
+        "key_status": "legacy", "has_api_key": True,
+        "message": "Rotate this legacy API key when convenient.",
     },
     "unsafe-legacy": {
         **LOCAL_NETWORK,
@@ -110,11 +138,17 @@ SETUP = {
 
 
 class FixtureState:
+    DELAY_KINDS = frozenset(("client", "agent", "network"))
+
     def __init__(self):
         self.lock = threading.Lock()
         self.network = copy.deepcopy(LOCAL_NETWORK)
+        self.models = copy.deepcopy(DEFAULT_MODELS)
+        self.active_engine = "llamacpp"
         self.fail_next_restart = False
         self.requests = []
+        self.delays = {}
+        self.delay_completed = {kind: 0 for kind in self.DELAY_KINDS}
 
     def record(self, method, path, body=None):
         with self.lock:
@@ -133,6 +167,67 @@ class FixtureState:
             self.network = copy.deepcopy(SCENARIOS[name])
             self.fail_next_restart = name == "forced-restart-failure"
         return True
+
+    def select_models(self, name):
+        scenario = MODEL_SCENARIOS.get(name)
+        if scenario is None:
+            return False
+        rows, active_engine = scenario
+        with self.lock:
+            self.models = copy.deepcopy(rows)
+            self.active_engine = active_engine
+        return True
+
+    def snapshot_models(self):
+        with self.lock:
+            return copy.deepcopy(self.models), self.active_engine
+
+    def arm_delay(self, kind, delay_ms=750):
+        if (kind not in self.DELAY_KINDS or not isinstance(delay_ms, int) or
+                delay_ms < 100 or delay_ms > 5000):
+            return False
+        event = threading.Event()
+        with self.lock:
+            previous = self.delays.get(kind)
+            self.delays[kind] = event
+        if previous is not None:
+            previous.set()
+        timer = threading.Timer(delay_ms / 1000, event.set)
+        timer.daemon = True
+        timer.start()
+        return True
+
+    def release_delay(self, kind):
+        if kind not in self.DELAY_KINDS:
+            return False
+        with self.lock:
+            event = self.delays.get(kind)
+        if event is None:
+            return False
+        event.set()
+        return True
+
+    def wait_delay(self, kind):
+        with self.lock:
+            event = self.delays.get(kind)
+        if event is not None:
+            event.wait(timeout=15)
+        return event
+
+    def complete_delay(self, kind, event):
+        if event is None:
+            return
+        with self.lock:
+            if self.delays.get(kind) is event:
+                del self.delays[kind]
+            self.delay_completed[kind] += 1
+
+    def snapshot_delays(self):
+        with self.lock:
+            return {
+                "pending": sorted(self.delays),
+                "completed": copy.deepcopy(self.delay_completed),
+            }
 
 
 class FixtureServer(ThreadingHTTPServer):
@@ -171,6 +266,13 @@ class FixtureHandler(BaseHTTPRequestHandler):
             return None
         return body
 
+    def _send_delayed(self, kind, status, payload):
+        event = self.server.fixture.wait_delay(kind)
+        try:
+            self._send(status, payload)
+        finally:
+            self.server.fixture.complete_delay(kind, event)
+
     def do_GET(self):
         path = urlsplit(self.path).path
         if path.startswith("/api/"):
@@ -178,18 +280,21 @@ class FixtureHandler(BaseHTTPRequestHandler):
         if path in ("/api/schema", "/api/vllm/schema"):
             self._send(200, SCHEMA)
         elif path == "/api/state":
+            models, active_engine = self.server.fixture.snapshot_models()
+            public_config = copy.deepcopy(PUBLIC_CONFIG)
+            public_config["active_engine"] = active_engine
             self._send(200, {
-                "models": MODELS,
+                "models": models,
                 "global": {},
                 "gpus": [],
-                "config": PUBLIC_CONFIG,
+                "config": public_config,
                 "platform": "windows",
                 "vllm_supported": True,
                 "backends": ["llamacpp", "vllm"],
-                "active_engine": "llamacpp",
+                "active_engine": active_engine,
                 "config_error": None,
                 "onboarding": {
-                    "server_bin_ok": True, "model_count": len(MODELS),
+                    "server_bin_ok": True, "model_count": len(models),
                     "ui_mode": "advanced", "onboarded": True,
                 },
             })
@@ -207,6 +312,8 @@ class FixtureHandler(BaseHTTPRequestHandler):
             self._send(404, {"error": "not found"})
         elif path == "/_fixture/requests":
             self._send(200, {"requests": self.server.fixture.snapshot_requests()})
+        elif path == "/_fixture/delays":
+            self._send(200, self.server.fixture.snapshot_delays())
         elif path == "/_fixture.js":
             self._send(200, FIXTURE_JS.read_text(encoding="utf-8"),
                        "text/javascript; charset=utf-8")
@@ -223,6 +330,25 @@ class FixtureHandler(BaseHTTPRequestHandler):
         if path == "/_fixture/scenario":
             if not isinstance(body, dict) or not self.server.fixture.select(body.get("name")):
                 self._send(400, {"ok": False, "error": "unknown fixture scenario"})
+            else:
+                self._send(200, {"ok": True})
+        elif path == "/_fixture/models":
+            if (not isinstance(body, dict) or
+                    not self.server.fixture.select_models(body.get("name"))):
+                self._send(400, {"ok": False, "error": "unknown model scenario"})
+            else:
+                self._send(200, {"ok": True})
+        elif path == "/_fixture/delay":
+            if (not isinstance(body, dict) or
+                    not self.server.fixture.arm_delay(
+                        body.get("kind"), body.get("delay_ms", 750))):
+                self._send(400, {"ok": False, "error": "unknown delay kind"})
+            else:
+                self._send(200, {"ok": True})
+        elif path == "/_fixture/release":
+            if (not isinstance(body, dict) or
+                    not self.server.fixture.release_delay(body.get("kind"))):
+                self._send(400, {"ok": False, "error": "delay not armed"})
             else:
                 self._send(200, {"ok": True})
         elif path == "/api/network":
@@ -299,7 +425,7 @@ class FixtureHandler(BaseHTTPRequestHandler):
             out["error"] = "Router restart failed; inspect Router Log."
         if action == "generate":
             out["generated_api_key"] = SENTINEL
-        self._send(500 if fail else 200, out)
+        self._send_delayed("network", 500 if fail else 200, out)
 
     def _post_client(self, body):
         if not isinstance(body, dict) or set(body) != {"model", "backend"}:
@@ -307,29 +433,34 @@ class FixtureHandler(BaseHTTPRequestHandler):
             return
         backend = body.get("backend")
         model = body.get("model")
-        if (backend, model) == ("llamacpp", "llama-fixture"):
+        if ((backend, model) == ("llamacpp", "llama-fixture") or
+                (backend in ("llamacpp", "ikllama") and
+                 model == "shared-fixture")):
             endpoint = "http://127.0.0.1:8080"
-            self._send(200, {
+            payload = {
                 "backend": backend, "endpoint": endpoint,
                 "auth_required": True, "model_loaded": True,
                 "curl": ("curl http://127.0.0.1:8080/v1/chat/completions "
                          "-H 'Authorization: Bearer " + SENTINEL + "'"),
                 "environment": ("OPENAI_BASE_URL=http://127.0.0.1:8080/v1\n"
                                 "OPENAI_API_KEY=" + SENTINEL),
-                "payload": '{"model":"llama-fixture","messages":[]}',
-            })
-        elif (backend, model) == ("vllm", "vllm-fixture"):
+                "payload": json.dumps({"model": model, "messages": []}),
+            }
+        elif (backend == "vllm" and
+              model in ("vllm-fixture", "shared-fixture")):
             endpoint = "http://127.0.0.1:8081"
-            self._send(200, {
+            payload = {
                 "backend": backend, "endpoint": endpoint,
                 "auth_required": False, "model_loaded": True,
                 "curl": "curl http://127.0.0.1:8081/v1/chat/completions",
                 "environment": ("OPENAI_BASE_URL=http://127.0.0.1:8081/v1\n"
                                 "OPENAI_API_KEY=not-required"),
-                "payload": '{"model":"vllm-fixture","messages":[]}',
-            })
+                "payload": json.dumps({"model": model, "messages": []}),
+            }
         else:
             self._send(400, {"error": "unknown client target"})
+            return
+        self._send_delayed("client", 200, payload)
 
     def _post_agent_config(self, body):
         expected = {"agent", "model", "backend", "small", "inject"}
@@ -338,7 +469,7 @@ class FixtureHandler(BaseHTTPRequestHandler):
                 body.get("backend") != "llamacpp"):
             self._send(400, {"error": "invalid agent request"})
             return
-        self._send(200, {
+        self._send_delayed("agent", 200, {
             "target_path": "fixture-agent.json",
             "endpoint": "http://127.0.0.1:8090/v1",
             "instructions": "Use the generated local fixture configuration.",

--- a/tools/security_ui_smoke.py
+++ b/tools/security_ui_smoke.py
@@ -1,0 +1,478 @@
+#!/usr/bin/env python3
+"""Local real-frontend smoke test for explicit credential handling.
+
+This fixture deliberately lives outside unittest discovery and CI.  It serves
+the repository's real browser application while replacing only the API surface
+needed by the security acceptance scenario.
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import mimetypes
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import threading
+from html.parser import HTMLParser
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WEB = ROOT / "web"
+FIXTURE_JS = Path(__file__).with_name("security_ui_smoke.js")
+SENTINEL = "fixture-secret-must-not-leak-" + "f" * 16
+
+PUBLIC_CONFIG = {
+    "theme": "dark",
+    "cvd": False,
+    "auto_load_model": "",
+    "vram_bandwidths": {},
+    "presets": {},
+    "preset_bindings": {},
+    "active_engine": "llamacpp",
+    "router_api_key_configured": False,
+}
+MODELS = [
+    {"id": "llama-fixture", "backend": "llamacpp", "status": "loaded",
+     "settings": {}, "modalities": ["text"], "in_ini": True,
+     "endpoint": "http://127.0.0.1:8080", "eff_ctx": 4096},
+    {"id": "vllm-fixture", "backend": "vllm", "status": "loaded",
+     "settings": {}, "modalities": ["text"], "in_ini": True,
+     "endpoint": "http://127.0.0.1:8081", "eff_ctx": 4096},
+]
+LOCAL_NETWORK = {
+    "access_scope": "local", "host": "127.0.0.1", "port": 8080,
+    "lan_ip": "192.168.1.44", "router_running": True,
+    "configured_security_status": "local", "listener_status": "listening",
+    "key_status": "absent", "has_api_key": False,
+    "remediation_required": False, "message": "",
+}
+
+SCENARIOS = {
+    "local-no-key": LOCAL_NETWORK,
+    "local-keyed": {
+        **LOCAL_NETWORK,
+        "configured_security_status": "local_keyed",
+        "key_status": "strong", "has_api_key": True,
+    },
+    "lan-protected": {
+        **LOCAL_NETWORK,
+        "access_scope": "lan", "host": "0.0.0.0",
+        "configured_security_status": "protected",
+        "key_status": "strong", "has_api_key": True,
+    },
+    "unsafe-legacy": {
+        **LOCAL_NETWORK,
+        "access_scope": "legacy", "host": "192.168.1.55",
+        "configured_security_status": "unsafe_legacy",
+        "key_status": "absent", "has_api_key": False,
+        "remediation_required": True,
+        "message": "Stored LAN policy is unsafe and the router start is refused.",
+    },
+    "forced-restart-failure": {
+        **LOCAL_NETWORK,
+        "configured_security_status": "local_keyed",
+        "key_status": "strong", "has_api_key": True,
+    },
+}
+
+SCHEMA = {
+    "count": 1,
+    "groups": [{
+        "name": "Fixture",
+        "knobs": [{
+            "key": "fixture-note", "aliases": ["fixture-note"],
+            "type": "string", "default": "", "desc": "Harmless fixture knob",
+        }],
+    }],
+}
+SETUP = {
+    "prereqs": {
+        "tools": {
+            "git": {"present": True, "version": "fixture"},
+            "cmake": {"present": True, "version": "fixture"},
+        },
+        "msvc": {"label": "C++ compiler", "present": True, "url": ""},
+        "cuda": {"applicable": False, "present": False, "version": ""},
+        "installers": {},
+    },
+    "hardware": {
+        "cpu": {"name": "Fixture CPU", "cores": 8, "threads": 16},
+        "gpus": [], "cmake_flags": {}, "notes": [],
+    },
+}
+
+
+class FixtureState:
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.network = copy.deepcopy(LOCAL_NETWORK)
+        self.fail_next_restart = False
+        self.requests = []
+
+    def record(self, method, path, body=None):
+        with self.lock:
+            self.requests.append({
+                "method": method, "path": path, "body": copy.deepcopy(body),
+            })
+
+    def snapshot_requests(self):
+        with self.lock:
+            return copy.deepcopy(self.requests)
+
+    def select(self, name):
+        if name not in SCENARIOS:
+            return False
+        with self.lock:
+            self.network = copy.deepcopy(SCENARIOS[name])
+            self.fail_next_restart = name == "forced-restart-failure"
+        return True
+
+
+class FixtureServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(self, address):
+        super().__init__(address, FixtureHandler)
+        self.fixture = FixtureState()
+
+
+class FixtureHandler(BaseHTTPRequestHandler):
+    server: FixtureServer
+
+    def log_message(self, _format, *args):
+        pass
+
+    def _send(self, status, payload, content_type="application/json; charset=utf-8"):
+        if isinstance(payload, str):
+            raw = payload.encode("utf-8")
+        else:
+            raw = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def _body(self):
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+            raw = self.rfile.read(length)
+            body = json.loads(raw.decode("utf-8")) if raw else {}
+        except (ValueError, UnicodeDecodeError, json.JSONDecodeError):
+            self._send(400, {"error": "invalid fixture request"})
+            return None
+        return body
+
+    def do_GET(self):
+        path = urlsplit(self.path).path
+        if path.startswith("/api/"):
+            self.server.fixture.record("GET", path, None)
+        if path in ("/api/schema", "/api/vllm/schema"):
+            self._send(200, SCHEMA)
+        elif path == "/api/state":
+            self._send(200, {
+                "models": MODELS,
+                "global": {},
+                "gpus": [],
+                "config": PUBLIC_CONFIG,
+                "platform": "windows",
+                "vllm_supported": True,
+                "backends": ["llamacpp", "vllm"],
+                "active_engine": "llamacpp",
+                "config_error": None,
+                "onboarding": {
+                    "server_bin_ok": True, "model_count": len(MODELS),
+                    "ui_mode": "advanced", "onboarded": True,
+                },
+            })
+        elif path in ("/api/router/log", "/api/vllm/log"):
+            self._send(200, {"log": "fixture idle"})
+        elif path == "/api/setup":
+            self._send(200, SETUP)
+        elif path == "/api/vllm/setup":
+            self._send(200, {"supported": False})
+        elif path == "/api/network":
+            with self.server.fixture.lock:
+                network = copy.deepcopy(self.server.fixture.network)
+            self._send(200, network)
+        elif path == "/api/agent/config":
+            self._send(404, {"error": "not found"})
+        elif path == "/_fixture/requests":
+            self._send(200, {"requests": self.server.fixture.snapshot_requests()})
+        elif path == "/_fixture.js":
+            self._send(200, FIXTURE_JS.read_text(encoding="utf-8"),
+                       "text/javascript; charset=utf-8")
+        else:
+            self._serve_static(path)
+
+    def do_POST(self):
+        path = urlsplit(self.path).path
+        body = self._body()
+        if body is None:
+            return
+        if path.startswith("/api/"):
+            self.server.fixture.record("POST", path, body)
+        if path == "/_fixture/scenario":
+            if not isinstance(body, dict) or not self.server.fixture.select(body.get("name")):
+                self._send(400, {"ok": False, "error": "unknown fixture scenario"})
+            else:
+                self._send(200, {"ok": True})
+        elif path == "/api/network":
+            self._post_network(body)
+        elif path == "/api/client/config":
+            self._post_client(body)
+        elif path == "/api/agent/config":
+            self._post_agent_config(body)
+        elif path == "/api/agent/apply":
+            self._send(200, {
+                "ok": True, "path": "fixture-agent.json", "backup": None,
+                "action": "updated",
+            })
+        else:
+            self._send(404, {"error": "not found"})
+
+    def _post_network(self, body):
+        allowed = {"access_scope", "key_action", "api_key"}
+        if (not isinstance(body, dict) or set(body) - allowed or
+                body.get("access_scope") not in ("local", "lan") or
+                body.get("key_action") not in ("keep", "generate", "replace", "clear")):
+            self._send(400, {"ok": False, "error": "invalid canonical network request"})
+            return
+        scope = body["access_scope"]
+        action = body["key_action"]
+        supplied = body.get("api_key")
+        if action == "replace":
+            if (not isinstance(supplied, str) or
+                    not re.fullmatch(r"[A-Za-z0-9._~-]{32,256}", supplied)):
+                self._send(400, {"ok": False, "error": "invalid replacement key"})
+                return
+        elif "api_key" in body:
+            self._send(400, {"ok": False, "error": "unexpected API key field"})
+            return
+
+        with self.server.fixture.lock:
+            current = self.server.fixture.network
+            has_key = bool(current.get("has_api_key"))
+            if action in ("generate", "replace"):
+                has_key = True
+            elif action == "clear":
+                has_key = False
+            if scope == "lan" and not has_key:
+                self._send(400, {"ok": False, "error": "LAN requires a key"})
+                return
+            if action == "clear" and scope != "local":
+                self._send(400, {"ok": False, "error": "LAN key cannot be removed"})
+                return
+
+            fail = self.server.fixture.fail_next_restart
+            self.server.fixture.fail_next_restart = False
+            configured = ("protected" if scope == "lan" else
+                          ("local_keyed" if has_key else "local"))
+            network = {
+                "access_scope": scope,
+                "host": "0.0.0.0" if scope == "lan" else "127.0.0.1",
+                "port": 8080, "lan_ip": "192.168.1.44",
+                "router_running": True,
+                "configured_security_status": configured,
+                "listener_status": "listening",
+                "key_status": "strong" if has_key else "absent",
+                "has_api_key": has_key,
+                "remediation_required": False, "message": "",
+            }
+            self.server.fixture.network = network
+
+        out = {
+            **copy.deepcopy(network),
+            "ok": not fail,
+            "saved": True,
+            "restart_status": "failed" if fail else "running",
+        }
+        if fail:
+            out["error"] = "Router restart failed; inspect Router Log."
+        if action == "generate":
+            out["generated_api_key"] = SENTINEL
+        self._send(500 if fail else 200, out)
+
+    def _post_client(self, body):
+        if not isinstance(body, dict) or set(body) != {"model", "backend"}:
+            self._send(400, {"error": "invalid client request"})
+            return
+        backend = body.get("backend")
+        model = body.get("model")
+        if (backend, model) == ("llamacpp", "llama-fixture"):
+            endpoint = "http://127.0.0.1:8080"
+            self._send(200, {
+                "backend": backend, "endpoint": endpoint,
+                "auth_required": True, "model_loaded": True,
+                "curl": ("curl http://127.0.0.1:8080/v1/chat/completions "
+                         "-H 'Authorization: Bearer " + SENTINEL + "'"),
+                "environment": ("OPENAI_BASE_URL=http://127.0.0.1:8080/v1\n"
+                                "OPENAI_API_KEY=" + SENTINEL),
+                "payload": '{"model":"llama-fixture","messages":[]}',
+            })
+        elif (backend, model) == ("vllm", "vllm-fixture"):
+            endpoint = "http://127.0.0.1:8081"
+            self._send(200, {
+                "backend": backend, "endpoint": endpoint,
+                "auth_required": False, "model_loaded": True,
+                "curl": "curl http://127.0.0.1:8081/v1/chat/completions",
+                "environment": ("OPENAI_BASE_URL=http://127.0.0.1:8081/v1\n"
+                                "OPENAI_API_KEY=not-required"),
+                "payload": '{"model":"vllm-fixture","messages":[]}',
+            })
+        else:
+            self._send(400, {"error": "unknown client target"})
+
+    def _post_agent_config(self, body):
+        expected = {"agent", "model", "backend", "small", "inject"}
+        if (not isinstance(body, dict) or set(body) != expected or
+                body.get("model") != "llama-fixture" or
+                body.get("backend") != "llamacpp"):
+            self._send(400, {"error": "invalid agent request"})
+            return
+        self._send(200, {
+            "target_path": "fixture-agent.json",
+            "endpoint": "http://127.0.0.1:8090/v1",
+            "instructions": "Use the generated local fixture configuration.",
+            "content": "fixture-agent-key=" + SENTINEL,
+        })
+
+    def _serve_static(self, path):
+        if path in ("", "/", "/index.html"):
+            target = WEB / "index.html"
+        elif path.startswith("/web/"):
+            relative = Path(unquote(path[len("/web/"):]))
+            target = WEB / relative
+        else:
+            self._send(404, {"error": "not found"})
+            return
+        try:
+            resolved = target.resolve(strict=True)
+            resolved.relative_to(WEB.resolve())
+        except (OSError, ValueError):
+            self._send(404, {"error": "not found"})
+            return
+        if resolved == (WEB / "index.html").resolve():
+            text = resolved.read_text(encoding="utf-8")
+            marker = '<script type="module" src="/_fixture.js"></script>'
+            text = text.replace("</body>", marker + "\n</body>", 1)
+            self._send(200, text, "text/html; charset=utf-8")
+            return
+        mime = mimetypes.guess_type(resolved.name)[0] or "application/octet-stream"
+        raw = resolved.read_bytes()
+        self.send_response(200)
+        self.send_header("Content-Type", mime)
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+
+class ResultParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.capture = False
+        self.status = None
+        self.text = []
+
+    def handle_starttag(self, tag, attrs):
+        values = dict(attrs)
+        if tag == "pre" and values.get("id") == "lf-security-result":
+            self.capture = True
+            self.status = values.get("data-status")
+
+    def handle_endtag(self, tag):
+        if tag == "pre" and self.capture:
+            self.capture = False
+
+    def handle_data(self, data):
+        if self.capture:
+            self.text.append(data)
+
+
+def _chrome_path(explicit):
+    candidates = [
+        explicit,
+        os.environ.get("LF_CHROME"),
+        r"C:\Program Files\Google\Chrome\Application\chrome.exe",
+        shutil.which("chrome"),
+        shutil.which("google-chrome"),
+    ]
+    for candidate in candidates:
+        if candidate and Path(candidate).is_file():
+            return str(Path(candidate))
+    return None
+
+
+def _redact(text):
+    return (text or "").replace(SENTINEL, "[fixture secret redacted]")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--chrome")
+    args = parser.parse_args(argv)
+    chrome = _chrome_path(args.chrome)
+    if not chrome:
+        print("FAIL: chrome-unavailable")
+        return 2
+
+    httpd = FixtureServer(("127.0.0.1", 0))
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        with tempfile.TemporaryDirectory(prefix="llamaforge-security-ui-") as profile:
+            url = "http://127.0.0.1:%d/#setup" % httpd.server_address[1]
+            command = [
+                chrome,
+                "--headless=new",
+                "--disable-gpu",
+                "--no-first-run",
+                "--no-default-browser-check",
+                "--disable-background-networking",
+                "--dump-dom",
+                "--virtual-time-budget=60000",
+                "--user-data-dir=" + profile,
+                url,
+            ]
+            try:
+                result = subprocess.run(
+                    command, capture_output=True, text=True, timeout=90,
+                    encoding="utf-8", errors="replace", check=False)
+            except (OSError, subprocess.TimeoutExpired):
+                print("FAIL: chrome-execution-failed")
+                return 2
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=5)
+
+    stdout = _redact(result.stdout)
+    stderr = _redact(result.stderr)
+    parsed = ResultParser()
+    parsed.feed(stdout)
+    message = "".join(parsed.text).strip()
+    if result.returncode == 0 and parsed.status == "pass" and message == "PASS":
+        print("PASS")
+        return 0
+    if parsed.status == "fail" and message:
+        print("FAIL: " + re.sub(r"[^a-z0-9-]", "-", message.lower()).strip("-"))
+    elif result.returncode:
+        diagnostic = next((line.strip() for line in stderr.splitlines() if line.strip()),
+                          "chrome returned a nonzero status")
+        print("FAIL: " + _redact(diagnostic))
+    else:
+        print("FAIL: missing-final-pass-marker")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web/index.html
+++ b/web/index.html
@@ -130,6 +130,30 @@ body.app{display:grid;grid-template-columns:var(--nav-w) 1fr;min-height:100vh;ma
    was clipping the row buttons, not the rows themselves. */
 .gpu .stats{display:flex;flex-wrap:wrap;gap:4px 14px;justify-content:space-between;margin-top:9px;color:var(--dim);font-size:11px}
 .gpu .stats b{color:var(--cyan-text);font-weight:500}
+.token-scale{display:flex;align-items:baseline;gap:9px;min-width:0;margin-bottom:10px;padding:9px 12px;
+  border:1px solid var(--amber-dim);background:linear-gradient(90deg,var(--amber-tint),transparent 70%);
+  font-family:var(--disp);letter-spacing:.04em;white-space:nowrap;position:relative;z-index:2}
+.token-scale-label{color:var(--amber-text);font-size:10px;letter-spacing:.16em;flex:none}
+.token-scale-total{color:var(--cyan-text);font-size:11px;font-weight:600;flex:none}
+.token-scale-mark{color:var(--amber-text);flex:none}
+.token-scale-fact{min-width:0;color:var(--ink-strong);font-weight:600;overflow:hidden;text-overflow:ellipsis}
+.token-scale-details{margin-left:auto;flex:none;color:var(--dim);font:9px var(--mono);letter-spacing:.14em}
+.token-scale-details summary{list-style:none;cursor:pointer;border-bottom:1px dotted var(--dim)}
+.token-scale-details summary::-webkit-details-marker{display:none}
+.token-scale-details summary:focus-visible{outline:1px solid var(--cyan);outline-offset:3px;color:var(--cyan-text)}
+.token-scale-note{position:absolute;right:0;top:calc(100% + 5px);width:min(540px,calc(100vw - 76px));padding:10px 12px;
+  border:1px solid var(--amber-dim);background:var(--panel2);box-shadow:0 8px 24px var(--shadow);white-space:normal;line-height:1.5;letter-spacing:0}
+.token-scale-note b,.token-scale-note span{display:block}.token-scale-note b{color:var(--ink-strong);font-weight:500}.token-scale-note span{color:var(--dim);margin-top:4px}
+.stats-vram{display:grid;grid-template-columns:repeat(auto-fit,minmax(210px,1fr));gap:8px;margin-bottom:14px}
+.stats-vram-card,.stats-vram-empty{background:var(--panel);border:1px solid var(--hair);padding:8px 10px}
+.stats-vram-head{display:flex;justify-content:space-between;gap:12px;margin-bottom:6px;color:var(--ink-hi);font-size:10px}
+.stats-vram-head span:first-child{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.stats-vram-head span:last-child{color:var(--amber-text);letter-spacing:.12em;flex:none}
+.stats-vram .meter{height:13px;padding:2px;gap:1px}
+.stats-vram .stats{display:flex;justify-content:space-between;gap:12px;margin-top:5px;color:var(--dim);font-size:9px}
+.stats-vram .stats b{color:var(--cyan-text);font-weight:500}
+.stats-vram-empty{grid-column:1/-1;color:var(--dim);font-size:9px;letter-spacing:.12em}
+@media(max-width:620px){.token-scale-label{display:none}.token-scale{gap:7px}.stats-vram{grid-template-columns:1fr}}
 .tbl-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:10px}
 .tbl-head h2{font-family:var(--disp);font-weight:600;letter-spacing:.18em;font-size:12px;color:var(--dim);text-transform:uppercase;margin:0}
 .count{color:var(--amber-text);font-size:11px}

--- a/web/index.html
+++ b/web/index.html
@@ -22,7 +22,7 @@
 <style>
 :root{
   --bg:#080a0b;--panel:#0f1315;--panel2:#141a1d;--hair:#1e262a;
-  --ink:#c8d2d4;--dim:#6b7a7e;--amber:#ffb000;--amber-dim:#7a5600;
+  --ink:#c8d2d4;--dim:#708084;--amber:#ffb000;--amber-dim:#7a5600;
   --cyan:#3fd7e6;--green:#39d98a;--red:#ff5c57;--grid:#0d1214;
   --mono:'JetBrains Mono',ui-monospace,monospace;--disp:'Chakra Petch',var(--mono);
   --ink-strong:#fff;--ink-hi:#e6eeef;--on-accent:#000;--on-amber:#120b00;
@@ -257,10 +257,35 @@ button:disabled{opacity:.4;cursor:not-allowed}
 .tunebar-cand-best{color:var(--amber-text);font-size:10px}
 .tunebar-cand.best{font-weight:600}
 /* modal (client config / compare) */
-.modal-bg{position:fixed;inset:0;background:var(--overlay-72);z-index:200;display:flex;align-items:flex-start;justify-content:center;padding:6vh 16px;overflow:auto}
 .modal{background:var(--panel);border:1px solid var(--amber);max-width:760px;width:100%;padding:20px 22px;box-shadow:0 10px 50px var(--shadow-70)}
 .modal h3{font-family:var(--disp);letter-spacing:.14em;text-transform:uppercase;font-size:13px;color:var(--amber-text);margin:0 0 4px}
 .modal .mclose{float:right;cursor:pointer;color:var(--dim);font-size:18px;line-height:1}.modal .mclose:hover{color:var(--red)}
+.modal-dialog,#net-confirm{
+  width:min(760px,calc(100vw - 32px));max-height:calc(100vh - 32px);
+  padding:0;border:0;background:transparent;color:var(--ink)
+}
+.modal-dialog::backdrop,#net-confirm::backdrop{background:#050708d9;backdrop-filter:blur(3px)}
+.modal-dialog .modal,#net-confirm .modal{
+  position:relative;max-height:calc(100vh - 48px);overflow:auto;
+  border:1px solid var(--amber);background:var(--panel);box-shadow:0 20px 70px #000b
+}
+.mclose{position:absolute;inset:10px 10px auto auto}
+#network-access fieldset{
+  margin:14px 0;padding:12px;border:1px solid var(--hair);display:grid;gap:9px
+}
+#network-access legend{padding:0 7px;color:var(--amber);letter-spacing:.06em}
+#network-access fieldset>label{display:flex;gap:8px;align-items:flex-start;min-height:48px;padding:4px 0}
+.modal-dialog button,#net-confirm button,#network-access button,#agent-connect .scopy{
+  min-width:48px;min-height:48px
+}
+.net-alert{padding:12px;border-left:3px solid var(--red);background:color-mix(in srgb,var(--red) 10%,transparent)}
+.net-observation{display:grid;gap:4px}
+.net-observation p{margin:0}
+.net-generated{margin-top:14px;padding:12px;border:1px solid var(--cyan)}
+.net-generated code{display:block;max-width:100%;margin:8px 0;overflow-wrap:anywhere}
+button:focus-visible,input:focus-visible,select:focus-visible{
+  outline:2px solid var(--cyan);outline-offset:2px
+}
 .snip{position:relative;background:var(--code-bg);border:1px solid var(--hair);padding:12px 12px;margin:8px 0 4px;font-size:11px;line-height:1.5;color:var(--code-ink);white-space:pre-wrap;word-break:break-all}
 .snip .scopy{position:absolute;top:6px;right:6px;font-size:9px;padding:4px 8px}
 .slabel{font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--dim);margin-top:14px}
@@ -444,7 +469,7 @@ body.mode-lite .advanced-only{display:none !important}
     (MIT, (c) The ggml authors). Not affiliated with llama.cpp / ggml-org.
   </div>
 </main>
-<div id="toast"></div>
+<div id="toast" role="status" aria-live="polite" aria-atomic="true"></div>
 <div id="modal-root"></div>
 <div id="wizard" class="wizard-overlay" hidden>
   <div class="wizard-card">

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -13,7 +13,7 @@ import * as stats from "./stats.js";
 import { loadDiscover } from "./discover.js";
 import { loadWillRun } from "./willrun.js";
 import { loadBuild } from "./build.js";
-import { loadSetup } from "./setup.js";
+import { leaveSetup, loadSetup } from "./setup.js";
 import { loadContext } from "./context.js";
 import { loadDocs } from "./help.js";
 import { initWizard } from "./wizard.js";
@@ -22,6 +22,7 @@ import { initOnboarding } from "./onboarding.js";
 /* ---------- tab loaders ---------- */
 ui.onTabShown("build", loadBuild);
 ui.onTabShown("setup", loadSetup);
+ui.onTabHidden("setup", leaveSetup);
 ui.onTabShown("discover", loadDiscover);
 ui.onTabShown("willrun", loadWillRun);
 ui.onTabShown("stats", stats.loadStats);

--- a/web/js/models.js
+++ b/web/js/models.js
@@ -232,6 +232,10 @@ function knobSig(m) {
                          : (S.SCHEMA ? S.SCHEMA.count||0 : -1), knobEpoch]);
 }
 
+function rowIdentity(backend, id) {
+  return JSON.stringify([backend || "llamacpp", id]);
+}
+
 export function renderModels() {
   if (!S.STATE) return;
   const all = modelRows();
@@ -249,17 +253,21 @@ export function renderModels() {
   if (!ms.length) { setHTML(list, `<div class="skel">NO MODELS MATCH</div>`); return; }
   if (list.firstElementChild && list.firstElementChild.classList.contains("skel")) setHTML(list, "");
 
-  const existing = new Map($$(".row", list).map(r => [r.dataset.id, r]));
+  const existing = new Map($$(".row", list).map(r => [
+    rowIdentity(r.dataset.backend, r.dataset.id), r,
+  ]));
   let prev = null;
   for (const m of ms) {
-    let row = existing.get(m.id);
+    const backend = m.backend || "llamacpp";
+    const identity = rowIdentity(backend, m.id);
+    let row = existing.get(identity);
     if (!row) {
       row = document.createElement("div");
       row.className = "row";
-      row.dataset.id = m.id;
-      row.dataset.backend = m.backend || "llamacpp";
       row.innerHTML = `<div class="rhead"></div><div class="edit"></div>`;
-    } else existing.delete(m.id);
+    } else existing.delete(identity);
+    row.dataset.id = m.id;
+    row.dataset.backend = backend;
 
     const hs = headSig(m, cols, showBackend);
     if (row._hs !== hs) {

--- a/web/js/models.js
+++ b/web/js/models.js
@@ -257,6 +257,7 @@ export function renderModels() {
       row = document.createElement("div");
       row.className = "row";
       row.dataset.id = m.id;
+      row.dataset.backend = m.backend || "llamacpp";
       row.innerHTML = `<div class="rhead"></div><div class="edit"></div>`;
     } else existing.delete(m.id);
 
@@ -379,30 +380,94 @@ function openCompare() {
 }
 
 /* ---------- modal ---------- */
-function closeModal() { setHTML($("#modal-root"), ""); }
-function showModal(title, inner) {
-  setHTML($("#modal-root"), `<div class="modal-bg"><div class="modal">
-    <span class="mclose" data-mclose>&times;</span><h3>${esc(title)}</h3>${inner}</div></div>`);
+function closeModal() {
+  const dialog = $("#modal-root dialog");
+  if (dialog && dialog.open) dialog.close();
+  else setHTML($("#modal-root"), "");
+}
+
+function showModal(title, inner, privateCopies = [], returnTo = document.activeElement) {
+  const root = $("#modal-root");
+  setHTML(root, `<dialog class="modal-dialog" aria-labelledby="modal-title">
+    <div class="modal">
+      <button type="button" class="mclose" data-mclose aria-label="Close dialog">&times;</button>
+      <h3 id="modal-title">${esc(title)}</h3>${inner}
+    </div>
+  </dialog>`);
+  const dialog = $("dialog", root);
+  const finish = () => {
+    setHTML(root, "");
+    if (returnTo && returnTo.isConnected) returnTo.focus();
+  };
+  dialog.addEventListener("close", finish, {once: true});
+  dialog.addEventListener("cancel", e => {
+    e.preventDefault();
+    dialog.close();
+  });
+  dialog.addEventListener("click", e => {
+    if (e.target === dialog) dialog.close();
+  });
+  $$("[data-private-copy-index]", dialog).forEach(button => {
+    const value = privateCopies[Number(button.dataset.privateCopyIndex)];
+    button.removeAttribute("data-private-copy-index");
+    button.onclick = e => {
+      e.stopPropagation();
+      navigator.clipboard.writeText(value).then(
+        () => toast("Copied to clipboard", "ok"));
+    };
+  });
+  dialog.showModal();
+  $("[data-mclose]", dialog).focus();
+  return {
+    returnTo,
+    isOpen: () => dialog.isConnected && dialog.open,
+    close: () => { if (dialog.open) dialog.close(); },
+  };
 }
 
 /* ---------- client config ---------- */
-function endpointFor(m) {
-  if (m.endpoint) return m.endpoint;
-  const c = cfgOf();
-  const host = (c.router_host && c.router_host !== "0.0.0.0") ? c.router_host : "127.0.0.1";
-  return `http://${host}:${c.router_port||8080}`;
-}
-function openClientConfig(id) {
-  const m = modelRows().find(x => x.id === id); if (!m) return;
-  const base = endpointFor(m), key = cfgOf().router_api_key || "";
-  const auth = key ? ` \\\n  -H "Authorization: Bearer ${key}"` : "";
-  const curl = `curl ${base}/v1/chat/completions \\\n  -H "Content-Type: application/json"${auth} \\\n  -d '{"model":"${id}","messages":[{"role":"user","content":"Hello"}]}'`;
-  const envs = `OPENAI_BASE_URL=${base}/v1\nOPENAI_API_KEY=${key||"not-required"}\n# model id: ${id}`;
-  const payload = JSON.stringify({model:id,messages:[{role:"user",content:"Hello"}],stream:false}, null, 2);
-  const snip = (label, text) => `<div class="slabel">${esc(label)}</div><div class="snip"><button class="qbtn scopy" data-copytext="${esc(text)}">Copy</button>${esc(text)}</div>`;
+async function openClientConfig(id, backend) {
+  const m = modelRows().find(
+    row => row.id === id && (row.backend || "llamacpp") === backend);
+  if (!m) return;
+  const pending = showModal(
+    "Client config - " + id,
+    `<div class="note" role="status">Generating configuration...</div>`);
+  let r;
+  try {
+    r = await api("/api/client/config", {model: m.id, backend});
+  } catch (error) {
+    if (pending.isOpen()) {
+      showModal("Client config - " + id,
+        `<div class="note" role="alert">Client configuration is unavailable.</div>`,
+        [], pending.returnTo);
+    }
+    return;
+  }
+  if (!pending.isOpen()) return;
+  if (r.error) {
+    showModal("Client config - " + id,
+      `<div class="note" role="alert">${esc(r.error)}</div>`,
+      [], pending.returnTo);
+    return;
+  }
+  const values = [r.curl, r.environment, r.payload];
+  const snip = (label, text, index) =>
+    `<div class="slabel">${esc(label)}</div><div class="snip">
+      <button type="button" class="qbtn scopy"
+              data-private-copy-index="${index}"
+              aria-label="Copy ${esc(label)}">Copy</button>${esc(text)}</div>`;
   showModal("Client config - " + id,
-    `<div class="note">This endpoint is OpenAI-compatible. ${key?"An API key is set and included below.":"No API key is set."}${m.status!=="loaded"?" <b style=\"color:var(--amber)\">Model isn't loaded - load it before sending requests.</b>":""}</div>`
-    + snip("curl", curl) + snip("OpenAI client (environment)", envs) + snip("Test JSON payload", payload));
+    `<div class="note">Endpoint: <b>${esc(r.endpoint)}</b>. ${
+      r.auth_required ? "The configured router credential is included." :
+                        "No API key is required for this target."}${
+      r.model_loaded ? "" :
+        ` <b style="color:var(--amber)">Load the model before sending requests.</b>`
+    }</div>` +
+    snip("curl", r.curl, 0) +
+    snip("OpenAI client (environment)", r.environment, 1) +
+    snip("Test JSON payload", r.payload, 2),
+    values, pending.returnTo);
 }
 
 /* ---------- presets ---------- */
@@ -616,7 +681,6 @@ export function initModels() {
   document.addEventListener("keydown", e => {
     const tag = (document.activeElement || {}).tagName || "";
     const typing = /INPUT|SELECT|TEXTAREA/.test(tag);
-    if (e.key === "Escape" && $("#modal-root").children.length) { closeModal(); return; }
     if (typing) {
       if (e.key === "Escape" && document.activeElement === $("#model-search")) {
         const inp = $("#model-search"); inp.value = ""; mquery = ""; renderModels(); inp.blur();
@@ -657,10 +721,7 @@ export function initModels() {
     if (favBtn) { e.stopPropagation(); toggleFav(favBtn.dataset.fav); return; }
     const onlySetChip = e.target.closest("#view-models [data-onlyset]");
     if (onlySetChip) { e.stopPropagation(); toggleOnlySet(onlySetChip); return; }
-    // modal controls (client config / compare)
-    if (e.target.closest("[data-mclose]") || (e.target.classList && e.target.classList.contains("modal-bg"))) { closeModal(); return; }
-    const scopy = e.target.closest("[data-copytext]");
-    if (scopy) { e.stopPropagation(); navigator.clipboard.writeText(scopy.dataset.copytext).then(() => toast("Copied to clipboard","ok")); return; }
+    if (e.target.closest("[data-mclose]")) { closeModal(); return; }
     // compare-pick checkbox
     const cmpBox = e.target.closest("[data-cmp]");
     if (cmpBox) {
@@ -697,6 +758,8 @@ export function initModels() {
     const btn = e.target.closest("#view-models button[data-act]");
     if (!btn) return;
     const row = btn.closest(".row"), id = row.dataset.id, msg = $("[data-msg]", row), act = btn.dataset.act;
+    const clientOpening = act === "client"
+      ? openClientConfig(id, row.dataset.backend) : null;
     btn.disabled = true;
     try {
       if (act === "save") {
@@ -717,7 +780,7 @@ export function initModels() {
         msg.className = "msg work"; msg.textContent = "unloading...";
         await api("/api/unload", {model: id}); toast("Unloaded", "ok");
       } else if (act === "client") {
-        openClientConfig(id); btn.disabled = false; return;
+        await clientOpening; return;
       } else if (act === "vsave") {
         const settings = {}; $$("[data-k]", row).forEach(el => settings[el.dataset.k] = el.value.trim());
         msg.className = "msg work"; msg.textContent = "saving vLLM knobs...";
@@ -733,7 +796,7 @@ export function initModels() {
         msg.className = "msg work"; msg.textContent = "stopping vLLM...";
         await api("/api/vllm/unload", {model: id}); toast("vLLM stopped", "ok");
       } else if (act === "vdelete") {
-        if (!confirm(`Delete ${id} and its files from WSL? This cannot be undone.`)) { btn.disabled = false; return; }
+        if (!confirm(`Delete ${id} and its files from WSL? This cannot be undone.`)) return;
         msg.className = "msg work"; msg.textContent = "deleting from WSL...";
         const r = await api("/api/vllm/delete", {model: id});
         r.ok ? toast("Deleted","ok") : (msg.className="msg err", msg.textContent=r.error||"delete failed");
@@ -741,6 +804,6 @@ export function initModels() {
       }
       await refresh(true);
     } catch (err) { msg.className = "msg err"; msg.textContent = String(err); }
-    btn.disabled = false;
+    finally { if (btn.isConnected) btn.disabled = false; }
   });
 }

--- a/web/js/setup.js
+++ b/web/js/setup.js
@@ -5,6 +5,40 @@ import { models, config as cfgOf } from "./state.js";
 import { emit } from "./bus.js";
 
 let vllmSetupPoll = null;
+let setupGeneration = 0;
+const setupCleanups = new Set();
+let clearAgentSecret = () => {};
+
+function setupViewActive(generation) {
+  const view = $("#view-setup");
+  return generation === setupGeneration &&
+    Boolean(view && view.classList.contains("active"));
+}
+
+function registerSetupCleanup(generation, cleanup) {
+  if (!setupViewActive(generation)) {
+    cleanup();
+    return () => {};
+  }
+  setupCleanups.add(cleanup);
+  return () => setupCleanups.delete(cleanup);
+}
+
+function invalidateSetup() {
+  setupGeneration += 1;
+  const cleanups = [...setupCleanups];
+  setupCleanups.clear();
+  for (const cleanup of cleanups) cleanup();
+  clearAgentSecret();
+  clearAgentSecret = () => {};
+  const out = $("#ac-out");
+  if (out) setHTML(out, "");
+  return setupGeneration;
+}
+
+export function leaveSetup() {
+  invalidateSetup();
+}
 
 function pollVllmSetup() {
   clearInterval(vllmSetupPoll);
@@ -40,6 +74,9 @@ function networkMarkup(net) {
           ? " A listener occupies the configured port; its process identity and protection cannot be verified."
           : ""}`
     : "";
+  const advisory = !net.remediation_required &&
+    net.configured_security_status === "protected_legacy"
+    ? (net.message || "Rotate this legacy API key when convenient.") : "";
   return `<section class="card" id="network-access" aria-labelledby="network-title">
     <h3 id="network-title">Network Access</h3>
     ${net.remediation_required ? `<div id="net-alert" class="net-alert" role="alert">
@@ -49,12 +86,16 @@ function networkMarkup(net) {
         <button type="button" id="net-remediate-local">Return to local-only</button>
       </div>
     </div>` : ""}
+    ${advisory ? `<div id="net-advisory" class="note">${esc(advisory)}</div>` : ""}
     <div class="net-observation">
-      <p><b>Configured:</b> <span id="net-configured">${esc(status)}</span></p>
+      <p><b>Configured policy:</b> <span id="net-configured">${esc(status)}</span></p>
+      <p><b>Configured endpoint:</b> <span id="net-configured-endpoint">http://${
+        esc(net.host)}:${esc(net.port)}/</span></p>
       <p><b>Observed listener:</b> <span id="net-runtime">${
         net.router_running ? "listening on the configured port" : "not listening"}</span></p>
       <p class="note">A listening port does not prove process identity or authentication.
-        LAN address: <b>http://${esc(net.lan_ip || "<lan-ip>")}:${esc(net.port)}/</b></p>
+        Convenience LAN URL: <b id="net-convenience-url">http://${
+          esc(net.lan_ip || "<lan-ip>")}:${esc(net.port)}/</b></p>
     </div>
     <fieldset id="net-scope-group" aria-describedby="net-scope-help net-apply-error">
       <legend>Access scope</legend>
@@ -103,7 +144,7 @@ function networkMarkup(net) {
   </section>`;
 }
 
-function confirmNetworkChange(title, message, confirmLabel) {
+function confirmNetworkChange(title, message, confirmLabel, generation) {
   return new Promise(resolve => {
     const root = $("#modal-root");
     const returnTo = document.activeElement;
@@ -123,12 +164,16 @@ function confirmNetworkChange(title, message, confirmLabel) {
     const cancel = $("#net-confirm-cancel");
     const accept = $("#net-confirm-accept");
     let finished = false;
+    let unregister = () => {};
     const finish = answer => {
       if (finished) return;
       finished = true;
+      unregister();
       if (dialog.open) dialog.close();
       setHTML(root, "");
-      if (returnTo && returnTo.isConnected) returnTo.focus();
+      if (returnTo && returnTo.isConnected && setupViewActive(generation)) {
+        returnTo.focus();
+      }
       resolve(answer);
     };
     cancel.onclick = () => finish(false);
@@ -149,6 +194,7 @@ function confirmNetworkChange(title, message, confirmLabel) {
     });
     dialog.showModal();
     cancel.focus();
+    unregister = registerSetupCleanup(generation, () => finish(false));
   });
 }
 
@@ -165,20 +211,20 @@ function networkFailureMessage(scope, listenerObserved = false) {
     : "The local-only configuration was saved, but the router is stopped; its listener is not currently active or verified.";
 }
 
-async function pollNetworkRuntime(root, savedScope) {
+async function pollNetworkRuntime(root, savedScope, generation) {
   const status = $("#net-status", root);
   const runtime = $("#net-runtime", root);
   const error = $("#net-apply-error", root);
   let latest = null;
   for (let attempt = 0; attempt < 10; attempt++) {
-    if (!root.isConnected) return;
+    if (!root.isConnected || !setupViewActive(generation)) return;
     let net;
     try {
       net = await api("/api/network");
     } catch (requestError) {
       break;
     }
-    if (!root.isConnected) return;
+    if (!root.isConnected || !setupViewActive(generation)) return;
     latest = net;
     runtime.textContent = net.router_running
       ? "listening on the configured port"
@@ -195,7 +241,7 @@ async function pollNetworkRuntime(root, savedScope) {
     }
     await new Promise(resolve => setTimeout(resolve, 500));
   }
-  if (root.isConnected) {
+  if (root.isConnected && setupViewActive(generation)) {
     status.className = "msg";
     status.textContent = "";
     error.hidden = false;
@@ -204,7 +250,7 @@ async function pollNetworkRuntime(root, savedScope) {
   }
 }
 
-function wireNetwork(net) {
+function wireNetwork(net, generation) {
   const root = $("#network-access");
   if (!root) return;
   const status = $("#net-status", root);
@@ -227,11 +273,11 @@ function wireNetwork(net) {
   let clearGenerated = hideGeneratedPanel;
 
   const installGeneratedSecret = rawSecret => {
+    if (!root.isConnected || !setupViewActive(generation)) return;
     clearGenerated();
     const privateKey = {value: String(rawSecret)};
     let revealTimer = null;
     let observer = null;
-    let leaveSetup = null;
 
     const destroy = () => {
       if (revealTimer !== null) clearTimeout(revealTimer);
@@ -245,8 +291,6 @@ function wireNetwork(net) {
       generatedReveal.disabled = true;
       generatedCopy.disabled = true;
       if (observer) observer.disconnect();
-      if (leaveSetup) document.removeEventListener("click", leaveSetup, true);
-      leaveSetup = null;
       generatedPanel.hidden = true;
       clearGenerated = hideGeneratedPanel;
     };
@@ -263,8 +307,6 @@ function wireNetwork(net) {
       generatedReveal.onclick = null;
       generatedCopy.onclick = null;
       if (observer) observer.disconnect();
-      if (leaveSetup) document.removeEventListener("click", leaveSetup, true);
-      leaveSetup = null;
       generatedDismiss.onclick = hideGeneratedPanel;
       clearGenerated = hideGeneratedPanel;
     };
@@ -295,20 +337,20 @@ function wireNetwork(net) {
       revealTimer = setTimeout(expire, 30_000);
     };
     generatedDismiss.onclick = destroy;
-    leaveSetup = event => {
-      const tab = event.target.closest?.(".tab");
-      if (tab && tab.dataset.tab !== "setup") destroy();
-    };
-    document.addEventListener("click", leaveSetup, true);
     observer = new MutationObserver(() => {
       const view = root.closest(".view");
-      if (!root.isConnected || !view || !view.classList.contains("active")) destroy();
+      if (!root.isConnected || !view || !view.classList.contains("active") ||
+          !setupViewActive(generation)) destroy();
     });
     observer.observe(document.body, {
       childList: true, subtree: true, attributes: true, attributeFilter: ["class"],
     });
     clearGenerated = destroy;
   };
+  registerSetupCleanup(generation, () => {
+    clearGenerated();
+    replaceInput.value = "";
+  });
 
   const scope = () => $('[name="net-scope"]:checked', root).value;
   const action = () => $('[name="net-key-action"]:checked', root).value;
@@ -395,33 +437,41 @@ function wireNetwork(net) {
       if (net.has_api_key && !await confirmNetworkChange(
           "Rotate router API key",
           "Existing clients will stop authenticating after restart until you update them.",
-          "Rotate key")) return;
+          "Rotate key", generation)) return;
     }
     if (keyAction === "generate" && net.has_api_key &&
         !await confirmNetworkChange(
           "Rotate router API key",
           "Generating a new key immediately invalidates the current key after restart.",
-          "Generate and rotate")) return;
+          "Generate and rotate", generation)) return;
     if (keyAction === "clear" && net.has_api_key && !await confirmNetworkChange(
         "Remove router API key",
         "Local clients will no longer need a key. LAN mode cannot run without one.",
-        "Remove key")) return;
+        "Remove key", generation)) return;
+
+    if (!setupViewActive(generation)) return;
 
     apply.disabled = true;
     status.className = "msg work";
     status.textContent = "Saving safe policy and restarting router...";
     try {
       const r = await api("/api/network", body);
-      if (!root.isConnected) return;
+      let issued = r.generated_api_key ? String(r.generated_api_key) : "";
+      delete r.generated_api_key;
+      if (!root.isConnected || !setupViewActive(generation)) {
+        issued = "";
+        return;
+      }
       $("#net-configured", root).textContent =
         String(r.configured_security_status || "saved").replaceAll("_", " ");
+      $("#net-configured-endpoint", root).textContent =
+        `http://${r.host || ""}:${r.port == null ? "" : r.port}/`;
       net.has_api_key = Boolean(r.has_api_key);
       $('[name="net-key-action"][value="keep"]', root).disabled =
         !net.has_api_key;
-      if (r.generated_api_key) {
-        const issued = r.generated_api_key;
-        delete r.generated_api_key;
+      if (issued) {
         installGeneratedSecret(issued);
+        issued = "";
       }
       if (!r.ok) {
         status.className = "msg";
@@ -434,22 +484,24 @@ function wireNetwork(net) {
           ? "listener present / not verified" : "not running / not verified";
         return;
       }
-      await pollNetworkRuntime(root, r.access_scope);
+      await pollNetworkRuntime(root, r.access_scope, generation);
     } catch (requestError) {
-      if (root.isConnected) {
+      if (root.isConnected && setupViewActive(generation)) {
         showError("The network change could not be completed.", apply);
       }
     } finally {
-      if (root.isConnected) apply.disabled = false;
+      if (root.isConnected && setupViewActive(generation)) apply.disabled = false;
     }
   };
   sync();
 }
 
 export async function loadSetup() {
+  const generation = invalidateSetup();
   const v = $("#view-setup");
   setHTML(v, `<div class="skel">PROBING SYSTEM...</div>`);
   const [s, net, vs] = await Promise.all([api("/api/setup"), api("/api/network"), api("/api/vllm/setup")]);
+  if (!setupViewActive(generation)) return;
   const p = s.prereqs, hw = s.hardware;
   const toolRow = (name, t) => `<div class="kv"><span class="k">${esc(name)}</span>
     <span class="v ${t.present?'ok':'bad'}">${t.present?esc(t.version||"present"):"MISSING"}
@@ -509,7 +561,7 @@ export async function loadSetup() {
       <div class="note">Downloads uv + a standalone Python and installs vLLM into ~/.llamaforge/vllm-venv. Several GB; watch the log.</div>`:""}
       <div class="log" id="vllm-setup-log" style="display:${(vs.setup_job&&vs.setup_job.running)?"":"none"}">${esc(vs.setup_log||"idle")}</div>
     </div>`));
-  wireNetwork(net);
+  wireNetwork(net, generation);
   $$("[data-install]", v).forEach(b => b.onclick = async () => {
     b.disabled = true; b.textContent = "installing...";
     const r = await api("/api/setup/install", {tool: b.dataset.install});
@@ -543,7 +595,7 @@ export async function loadSetup() {
     else msg.textContent = "already running";
   };
   if (vs.setup_job && vs.setup_job.running) pollVllmSetup();
-  renderAgentConnect();
+  renderAgentConnect(generation);
 }
 
 /* ---------- connect an agent ---------- */
@@ -561,6 +613,8 @@ function agentModelOptions(selected = "") {
 }
 
 function clearAgentPreview(message = "Choose settings, then show the configuration.") {
+  clearAgentSecret();
+  clearAgentSecret = () => {};
   const out = $("#ac-out");
   if (out) setHTML(out, `<div class="note">${esc(message)}</div>`);
 }
@@ -579,7 +633,7 @@ function agentRequest() {
   };
 }
 
-function renderAgentConnect() {
+function renderAgentConnect(generation) {
   const host = $("#agent-connect");
   if (!host) return;
   setHTML(host, `<h3>Connect an agent</h3>
@@ -617,12 +671,13 @@ function renderAgentConnect() {
   $("#ac-model").onchange = () => clearAgentPreview();
   $("#ac-small").onchange = () => clearAgentPreview();
   $("#ac-inject").onchange = () => clearAgentPreview();
-  $("#ac-show").onclick = showAgentConfig;
-  $("#ac-apply").onclick = applyAgentConfig;
+  $("#ac-show").onclick = () => showAgentConfig(generation);
+  $("#ac-apply").onclick = () => applyAgentConfig(generation);
   sync();
 }
 
-async function showAgentConfig() {
+async function showAgentConfig(generation) {
+  if (!setupViewActive(generation)) return;
   const body = agentRequest();
   if (!body) {
     clearAgentPreview("No llama-family model is available.");
@@ -631,10 +686,14 @@ async function showAgentConfig() {
   }
   const out = $("#ac-out");
   const stillCurrent = () => {
-    if (!out.isConnected || out !== $("#ac-out")) return false;
+    if (!setupViewActive(generation) || !out.isConnected || out !== $("#ac-out")) {
+      return false;
+    }
     const current = agentRequest();
     return current !== null && JSON.stringify(current) === JSON.stringify(body);
   };
+  clearAgentSecret();
+  clearAgentSecret = () => {};
   setHTML(out,
     `<div class="note" role="status">Generating configuration...</div>`);
   let r;
@@ -647,45 +706,72 @@ async function showAgentConfig() {
     }
     return;
   }
-  if (!stillCurrent()) return;
+  if (!stillCurrent()) {
+    if (r && typeof r.content === "string") r.content = "";
+    return;
+  }
   if (r.error) {
     setHTML(out,
       `<div class="note" role="alert">${esc(r.error)}</div>`);
     return;
   }
-  const privateValues = [r.content];
+  let privateValue = String(r.content || "");
+  r.content = "";
   setHTML(out,
     `<div class="note">Target: <b>${esc(r.target_path)}</b> · endpoint
       <b>${esc(r.endpoint)}</b><br>${esc(r.instructions)}</div>
       <div class="slabel">${esc(r.target_path)}</div>
       <div class="snip"><button type="button" class="qbtn scopy"
         data-agent-copy-index="0" aria-label="Copy agent configuration">Copy</button>${
-        esc(r.content)}</div>`);
-  $$("[data-agent-copy-index]", out).forEach(button => {
-    const value = privateValues[Number(button.dataset.agentCopyIndex)];
+        esc(privateValue)}</div>`);
+  const buttons = $$("[data-agent-copy-index]", out);
+  for (const button of buttons) {
     button.removeAttribute("data-agent-copy-index");
-    button.onclick = () => navigator.clipboard.writeText(value).then(
-      () => toast("Copied to clipboard", "ok"));
-  });
+    button.onclick = () => {
+      if (!privateValue) return;
+      navigator.clipboard.writeText(privateValue).then(
+        () => toast("Copied to clipboard", "ok"));
+    };
+  }
+  let unregister = () => {};
+  const destroy = () => {
+    privateValue = "";
+    for (const button of buttons) button.onclick = null;
+    if (out.isConnected && out === $("#ac-out")) setHTML(out, "");
+    unregister();
+    if (clearAgentSecret === destroy) clearAgentSecret = () => {};
+  };
+  clearAgentSecret = destroy;
+  unregister = registerSetupCleanup(generation, destroy);
 }
 
-async function applyAgentConfig() {
+async function applyAgentConfig(generation) {
+  if (!setupViewActive(generation)) return;
   const body = agentRequest();
   if (!body) {
     clearAgentPreview("No llama-family model is available.");
     $("#ac-model").focus();
     return;
   }
+  const out = $("#ac-out");
+  const stillCurrent = () => {
+    if (!setupViewActive(generation) || !out.isConnected || out !== $("#ac-out")) {
+      return false;
+    }
+    const current = agentRequest();
+    return current !== null && JSON.stringify(current) === JSON.stringify(body);
+  };
   let r;
   try {
     r = await api("/api/agent/apply", body);
   } catch (requestError) {
-    setHTML($("#ac-out"),
+    if (stillCurrent()) setHTML(out,
       `<div class="note" role="alert">Agent configuration could not be applied.</div>`);
     return;
   }
+  if (!stillCurrent()) return;
   if (r.error) {
-    setHTML($("#ac-out"),
+    setHTML(out,
       `<div class="note" role="alert">${esc(r.error)}</div>`);
     return;
   }

--- a/web/js/setup.js
+++ b/web/js/setup.js
@@ -1,7 +1,7 @@
 // Setup tab: prerequisites, detected hardware, drive scanning, startup options,
 // LAN access, the agent-connect panel, and vLLM/WSL installation.
 import { $, $$, esc, setHTML, api, toast } from "./core.js";
-import { S, models, config as cfgOf } from "./state.js";
+import { models, config as cfgOf } from "./state.js";
 import { emit } from "./bus.js";
 
 let vllmSetupPoll = null;
@@ -26,6 +26,424 @@ function pollVllmSetup() {
   };
   tick();
   vllmSetupPoll = setInterval(tick, 2000);
+}
+
+function networkMarkup(net) {
+  const local = net.access_scope === "local";
+  const hasKey = Boolean(net.has_api_key);
+  const initialAction = hasKey ? "keep" : (local ? "clear" : "generate");
+  const checked = value => initialAction === value ? " checked" : "";
+  const status = net.configured_security_status.replaceAll("_", " ");
+  const remediation = net.remediation_required
+    ? `${net.message || "The stored network configuration must be repaired."}${
+        net.router_running
+          ? " A listener occupies the configured port; its process identity and protection cannot be verified."
+          : ""}`
+    : "";
+  return `<section class="card" id="network-access" aria-labelledby="network-title">
+    <h3 id="network-title">Network Access</h3>
+    ${net.remediation_required ? `<div id="net-alert" class="net-alert" role="alert">
+      ${esc(remediation)}
+      <div class="actions">
+        <button type="button" id="net-remediate-generate">Secure with a generated key</button>
+        <button type="button" id="net-remediate-local">Return to local-only</button>
+      </div>
+    </div>` : ""}
+    <div class="net-observation">
+      <p><b>Configured:</b> <span id="net-configured">${esc(status)}</span></p>
+      <p><b>Observed listener:</b> <span id="net-runtime">${
+        net.router_running ? "listening on the configured port" : "not listening"}</span></p>
+      <p class="note">A listening port does not prove process identity or authentication.
+        LAN address: <b>http://${esc(net.lan_ip || "<lan-ip>")}:${esc(net.port)}/</b></p>
+    </div>
+    <fieldset id="net-scope-group" aria-describedby="net-scope-help net-apply-error">
+      <legend>Access scope</legend>
+      <label><input type="radio" name="net-scope" value="local"${
+        local ? " checked" : ""}> This computer only — recommended</label>
+      <label><input type="radio" name="net-scope" value="lan"${
+        local ? "" : " checked"}> Devices on my local network</label>
+      <p class="note" id="net-scope-help">LAN access always requires a usable API key.</p>
+    </fieldset>
+    <fieldset id="net-auth-group" aria-describedby="net-auth-help net-apply-error">
+      <legend>Authentication</legend>
+      <label><input type="radio" name="net-key-action" value="keep"${
+        checked("keep")} ${hasKey ? "" : "disabled"}> Keep the configured key</label>
+      <label><input type="radio" name="net-key-action" value="generate"${
+        checked("generate")}> Generate a new strong key</label>
+      <label><input type="radio" name="net-key-action" value="replace"${
+        checked("replace")}> Replace with a key I provide</label>
+      <label><input type="radio" name="net-key-action" value="clear"${
+        checked("clear")}> Remove the key (local-only)</label>
+      <p class="note" id="net-auth-help">Blank input never means keep or remove.
+        Rotating a key requires updating every router client after restart.</p>
+      <div class="fld" id="net-replace-wrap" hidden>
+        <label for="net-replace-key">Replacement API key</label>
+        <input id="net-replace-key" type="password" autocomplete="new-password"
+               minlength="32" maxlength="256"
+               aria-describedby="net-replace-help net-apply-error">
+        <div class="hint" id="net-replace-help">32–256 URL-safe characters:
+          letters, digits, dot, underscore, tilde, or hyphen.</div>
+      </div>
+    </fieldset>
+    <div class="actions">
+      <button type="button" class="primary" id="net-apply"
+              aria-describedby="net-apply-error">Apply &amp; Restart Router</button>
+      <span id="net-status" class="msg" role="status" aria-live="polite"></span>
+    </div>
+    <div id="net-apply-error" class="note" role="alert" hidden></div>
+    <div id="net-generated" class="net-generated" hidden>
+      <div>Generated API key — copy it now</div>
+      <code id="net-generated-display" aria-label="Generated API key masked">••••••••••••••••</code>
+      <button type="button" id="net-reveal-generated" aria-pressed="false">Reveal for 30 seconds</button>
+      <button type="button" id="net-copy-generated">Copy</button>
+      <button type="button" id="net-dismiss-generated">Done</button>
+      <div class="note">Copy does not render plaintext. Reveal expires after 30 seconds.
+        Retry, Done, navigation, or Setup rerender clears this one-time value.</div>
+    </div>
+  </section>`;
+}
+
+function confirmNetworkChange(title, message, confirmLabel) {
+  return new Promise(resolve => {
+    const root = $("#modal-root");
+    const returnTo = document.activeElement;
+    setHTML(root, `<dialog id="net-confirm" aria-labelledby="net-confirm-title"
+      aria-describedby="net-confirm-message">
+      <div class="modal">
+        <h3 id="net-confirm-title">${esc(title)}</h3>
+        <p id="net-confirm-message">${esc(message)}</p>
+        <div class="actions">
+          <button type="button" id="net-confirm-cancel">Cancel</button>
+          <button type="button" class="primary" id="net-confirm-accept">${
+            esc(confirmLabel)}</button>
+        </div>
+      </div>
+    </dialog>`);
+    const dialog = $("#net-confirm");
+    const cancel = $("#net-confirm-cancel");
+    const accept = $("#net-confirm-accept");
+    let finished = false;
+    const finish = answer => {
+      if (finished) return;
+      finished = true;
+      if (dialog.open) dialog.close();
+      setHTML(root, "");
+      if (returnTo && returnTo.isConnected) returnTo.focus();
+      resolve(answer);
+    };
+    cancel.onclick = () => finish(false);
+    accept.onclick = () => finish(true);
+    dialog.addEventListener("cancel", event => {
+      event.preventDefault();
+      finish(false);
+    });
+    dialog.addEventListener("keydown", event => {
+      if (event.key !== "Tab") return;
+      if (event.shiftKey && document.activeElement === cancel) {
+        event.preventDefault();
+        accept.focus();
+      } else if (!event.shiftKey && document.activeElement === accept) {
+        event.preventDefault();
+        cancel.focus();
+      }
+    });
+    dialog.showModal();
+    cancel.focus();
+  });
+}
+
+const STRONG_NETWORK_KEY = /^[A-Za-z0-9._~-]{32,256}$/;
+
+function networkFailureMessage(scope, listenerObserved = false) {
+  if (listenerObserved) {
+    return scope === "lan"
+      ? "A protected configuration was saved, but restart failed; a listener is present and its process identity and protection are not verified."
+      : "The local-only configuration was saved, but restart failed; a listener is present and its process identity is not verified.";
+  }
+  return scope === "lan"
+    ? "A protected configuration was saved, but the router is stopped; LAN protection is not currently active or verified."
+    : "The local-only configuration was saved, but the router is stopped; its listener is not currently active or verified.";
+}
+
+async function pollNetworkRuntime(root, savedScope) {
+  const status = $("#net-status", root);
+  const runtime = $("#net-runtime", root);
+  const error = $("#net-apply-error", root);
+  let latest = null;
+  for (let attempt = 0; attempt < 10; attempt++) {
+    if (!root.isConnected) return;
+    let net;
+    try {
+      net = await api("/api/network");
+    } catch (requestError) {
+      break;
+    }
+    if (!root.isConnected) return;
+    latest = net;
+    runtime.textContent = net.router_running
+      ? "listening on the configured port"
+      : "not listening";
+    if (net.router_running) {
+      const protection = String(
+        net.configured_security_status || "configured").replaceAll("_", " ");
+      const endpointHost = net.access_scope === "lan"
+        ? (net.lan_ip || "<LAN-IP>") : "127.0.0.1";
+      status.className = "msg ok";
+      status.textContent = `Saved ${protection} settings; listener observed at http://${
+        endpointHost}:${net.port}/.`;
+      return;
+    }
+    await new Promise(resolve => setTimeout(resolve, 500));
+  }
+  if (root.isConnected) {
+    status.className = "msg";
+    status.textContent = "";
+    error.hidden = false;
+    error.textContent = `${networkFailureMessage(latest?.access_scope || savedScope)} ` +
+      "Check Router Log for the launch error, then retry Apply.";
+  }
+}
+
+function wireNetwork(net) {
+  const root = $("#network-access");
+  if (!root) return;
+  const status = $("#net-status", root);
+  const error = $("#net-apply-error", root);
+  const apply = $("#net-apply", root);
+  const replaceWrap = $("#net-replace-wrap", root);
+  const replaceInput = $("#net-replace-key", root);
+  const generatedPanel = $("#net-generated", root);
+  const generatedDisplay = $("#net-generated-display", root);
+  const generatedReveal = $("#net-reveal-generated", root);
+  const generatedCopy = $("#net-copy-generated", root);
+  const generatedDismiss = $("#net-dismiss-generated", root);
+
+  const hideGeneratedPanel = () => {
+    generatedDisplay.textContent = "";
+    generatedDisplay.setAttribute("aria-label", "Generated API key cleared");
+    generatedPanel.hidden = true;
+    generatedDismiss.onclick = null;
+  };
+  let clearGenerated = hideGeneratedPanel;
+
+  const installGeneratedSecret = rawSecret => {
+    clearGenerated();
+    const privateKey = {value: String(rawSecret)};
+    let revealTimer = null;
+    let observer = null;
+    let leaveSetup = null;
+
+    const destroy = () => {
+      if (revealTimer !== null) clearTimeout(revealTimer);
+      revealTimer = null;
+      privateKey.value = "";
+      generatedDisplay.textContent = "";
+      generatedDisplay.setAttribute("aria-label", "Generated API key cleared");
+      generatedReveal.onclick = null;
+      generatedCopy.onclick = null;
+      generatedDismiss.onclick = null;
+      generatedReveal.disabled = true;
+      generatedCopy.disabled = true;
+      if (observer) observer.disconnect();
+      if (leaveSetup) document.removeEventListener("click", leaveSetup, true);
+      leaveSetup = null;
+      generatedPanel.hidden = true;
+      clearGenerated = hideGeneratedPanel;
+    };
+
+    const expire = () => {
+      revealTimer = null;
+      privateKey.value = "";
+      generatedDisplay.textContent = "••••••••••••••••";
+      generatedDisplay.setAttribute("aria-label", "Generated API key expired");
+      generatedReveal.textContent = "Expired";
+      generatedReveal.setAttribute("aria-pressed", "false");
+      generatedReveal.disabled = true;
+      generatedCopy.disabled = true;
+      generatedReveal.onclick = null;
+      generatedCopy.onclick = null;
+      if (observer) observer.disconnect();
+      if (leaveSetup) document.removeEventListener("click", leaveSetup, true);
+      leaveSetup = null;
+      generatedDismiss.onclick = hideGeneratedPanel;
+      clearGenerated = hideGeneratedPanel;
+    };
+
+    generatedDisplay.textContent = "••••••••••••••••";
+    generatedDisplay.setAttribute("aria-label", "Generated API key masked");
+    generatedReveal.textContent = "Reveal for 30 seconds";
+    generatedReveal.setAttribute("aria-pressed", "false");
+    generatedReveal.disabled = false;
+    generatedCopy.disabled = false;
+    generatedPanel.hidden = false;
+
+    generatedCopy.onclick = () => {
+      if (!privateKey.value) return;
+      navigator.clipboard.writeText(privateKey.value).then(() => {
+        status.className = "msg ok";
+        status.textContent = "Generated key copied.";
+      });
+    };
+    generatedReveal.onclick = () => {
+      if (!privateKey.value || revealTimer !== null) return;
+      generatedDisplay.textContent = privateKey.value;
+      generatedDisplay.setAttribute(
+        "aria-label", "Generated API key revealed temporarily");
+      generatedReveal.textContent = "Revealed — expires in 30 seconds";
+      generatedReveal.setAttribute("aria-pressed", "true");
+      generatedReveal.disabled = true;
+      revealTimer = setTimeout(expire, 30_000);
+    };
+    generatedDismiss.onclick = destroy;
+    leaveSetup = event => {
+      const tab = event.target.closest?.(".tab");
+      if (tab && tab.dataset.tab !== "setup") destroy();
+    };
+    document.addEventListener("click", leaveSetup, true);
+    observer = new MutationObserver(() => {
+      const view = root.closest(".view");
+      if (!root.isConnected || !view || !view.classList.contains("active")) destroy();
+    });
+    observer.observe(document.body, {
+      childList: true, subtree: true, attributes: true, attributeFilter: ["class"],
+    });
+    clearGenerated = destroy;
+  };
+
+  const scope = () => $('[name="net-scope"]:checked', root).value;
+  const action = () => $('[name="net-key-action"]:checked', root).value;
+  const chooseAction = value => {
+    const radio = $(`[name="net-key-action"][value="${value}"]`, root);
+    if (radio && !radio.disabled) radio.checked = true;
+  };
+  let invalidControl = null;
+  const clearInvalid = () => {
+    if (!invalidControl) return;
+    invalidControl.removeAttribute("aria-invalid");
+    invalidControl.removeAttribute("aria-errormessage");
+    invalidControl = null;
+  };
+  const showError = (message, focus) => {
+    clearInvalid();
+    error.hidden = false;
+    error.textContent = message;
+    status.className = "msg";
+    status.textContent = "";
+    if (focus) {
+      invalidControl = focus;
+      focus.setAttribute("aria-invalid", "true");
+      focus.setAttribute("aria-errormessage", "net-apply-error");
+      focus.focus();
+    }
+  };
+  const clearError = () => {
+    clearInvalid();
+    error.hidden = true;
+    error.textContent = "";
+  };
+  const sync = () => {
+    const lan = scope() === "lan";
+    const clear = $('[name="net-key-action"][value="clear"]', root);
+    clear.disabled = lan;
+    if (lan && clear.checked) chooseAction(net.has_api_key ? "keep" : "generate");
+    replaceWrap.hidden = action() !== "replace";
+    clearError();
+  };
+
+  $$('[name="net-scope"], [name="net-key-action"]', root).forEach(
+    control => control.onchange = sync);
+  const localRemediation = $("#net-remediate-local", root);
+  if (localRemediation) localRemediation.onclick = () => {
+    $('[name="net-scope"][value="local"]', root).checked = true;
+    sync();
+    chooseAction(net.has_api_key ? "keep" : "clear");
+    sync();
+    apply.focus();
+  };
+  const generateRemediation = $("#net-remediate-generate", root);
+  if (generateRemediation) generateRemediation.onclick = () => {
+    $('[name="net-scope"][value="lan"]', root).checked = true;
+    chooseAction("generate");
+    sync();
+    apply.focus();
+  };
+
+  apply.onclick = async () => {
+    clearError();
+    clearGenerated();
+    const desiredScope = scope();
+    const keyAction = action();
+    if (desiredScope === "lan" && keyAction === "keep" && !net.has_api_key) {
+      const generate = $('[name="net-key-action"][value="generate"]', root);
+      showError("LAN access requires Generate or a valid replacement key.", generate);
+      return;
+    }
+    if (desiredScope === "lan" && keyAction === "clear") {
+      const generate = $('[name="net-key-action"][value="generate"]', root);
+      showError("A key cannot be removed while LAN access is selected.", generate);
+      return;
+    }
+    const body = {access_scope: desiredScope, key_action: keyAction};
+    if (keyAction === "replace") {
+      const replacement = replaceInput.value.trim();
+      if (!STRONG_NETWORK_KEY.test(replacement)) {
+        showError("Enter a 32–256 character URL-safe replacement key.",
+                  replaceInput);
+        return;
+      }
+      body.api_key = replacement;
+      if (net.has_api_key && !await confirmNetworkChange(
+          "Rotate router API key",
+          "Existing clients will stop authenticating after restart until you update them.",
+          "Rotate key")) return;
+    }
+    if (keyAction === "generate" && net.has_api_key &&
+        !await confirmNetworkChange(
+          "Rotate router API key",
+          "Generating a new key immediately invalidates the current key after restart.",
+          "Generate and rotate")) return;
+    if (keyAction === "clear" && net.has_api_key && !await confirmNetworkChange(
+        "Remove router API key",
+        "Local clients will no longer need a key. LAN mode cannot run without one.",
+        "Remove key")) return;
+
+    apply.disabled = true;
+    status.className = "msg work";
+    status.textContent = "Saving safe policy and restarting router...";
+    try {
+      const r = await api("/api/network", body);
+      if (!root.isConnected) return;
+      $("#net-configured", root).textContent =
+        String(r.configured_security_status || "saved").replaceAll("_", " ");
+      net.has_api_key = Boolean(r.has_api_key);
+      $('[name="net-key-action"][value="keep"]', root).disabled =
+        !net.has_api_key;
+      if (r.generated_api_key) {
+        const issued = r.generated_api_key;
+        delete r.generated_api_key;
+        installGeneratedSecret(issued);
+      }
+      if (!r.ok) {
+        status.className = "msg";
+        status.textContent = "";
+        error.hidden = false;
+        error.textContent = `${networkFailureMessage(
+          r.access_scope, Boolean(r.router_running))} ${
+          r.error || "Open Router Log for details, then retry Apply."}`;
+        $("#net-runtime", root).textContent = r.router_running
+          ? "listener present / not verified" : "not running / not verified";
+        return;
+      }
+      await pollNetworkRuntime(root, r.access_scope);
+    } catch (requestError) {
+      if (root.isConnected) {
+        showError("The network change could not be completed.", apply);
+      }
+    } finally {
+      if (root.isConnected) apply.disabled = false;
+    }
+  };
+  sync();
 }
 
 export async function loadSetup() {
@@ -69,33 +487,14 @@ export async function loadSetup() {
       <div id="missing-out"></div>
     </div>
     <div class="card"><h3>Startup</h3>
-      <div class="kv"><span class="k">auto-load a model on launch</span>
+      <div class="kv"><label class="k" for="auto-load">auto-load a model on launch</label>
         <span class="v"><select id="auto-load" style="background:var(--inset);border:1px solid var(--hair);color:var(--ink);font-family:var(--mono);font-size:12px;padding:6px">
           <option value="">none</option>
           ${models().map(m=>`<option value="${esc(m.id)}" ${cfgOf().auto_load_model===m.id?"selected":""}>${esc(m.id)}</option>`).join("")}
         </select></span></div>
       <div class="note">The selected model loads automatically once the router is ready after launch &mdash; handy for always-on setups. An optional tray icon (loaded-model count, quick open) is available if you <b>pip install pystray pillow</b>; without them LlamaForge stays pure-stdlib.</div>
     </div>
-    <div class="card"><h3>Network Access</h3>
-      <div class="kv"><span class="k">router status</span><span class="v ${net.router_running?'ok':'bad'}">${net.router_running?"running":"not running"}</span></div>
-      <div class="kv"><span class="k">currently bound to</span><span class="v">${esc(net.host)}:${esc(net.port)}${net.host!=="127.0.0.1"?" (LAN-accessible)":" (local only)"}</span></div>
-      <div class="kv"><span class="k">this machine's LAN IP</span><span class="v">${esc(net.lan_ip||"not detected")}</span></div>
-      <div class="note">By default the router only answers on 127.0.0.1 (this machine only). Enabling LAN access lets other devices on your network reach it at <b>http://${esc(net.lan_ip||"<lan-ip>")}:${esc(net.port)}/</b> &mdash; with no key set, anyone on your network can use it unauthenticated. An API key is optional but recommended.</div>
-      <div class="actions" style="margin-top:10px">
-        <label style="font-size:11px;color:var(--dim)"><input type="checkbox" id="net-lan" ${net.host!=="127.0.0.1"?"checked":""}> allow access from other devices on my network</label>
-      </div>
-      <div id="net-keyrow" style="display:${net.host!=="127.0.0.1"?"":"none"};margin-top:10px">
-        <label style="font-size:11px;color:var(--dim);display:block;margin-bottom:8px"><input type="checkbox" id="net-require-key" checked> require an API key (won't enable LAN access until a key is set)</label>
-        <div class="fld"><label>API key (clients send it as Authorization: Bearer &lt;key&gt;)</label>
-          <input id="net-apikey" value="" placeholder="${net.has_api_key?"(unchanged - a key is already set)":"leave blank for no key"}">
-        </div>
-      </div>
-      <div class="actions" style="margin-top:10px">
-        <button class="primary" id="btn-net-apply">Apply &amp; Restart Router</button>
-        <button class="ghost" id="btn-net-genkey" style="display:${net.host!=="127.0.0.1"?"":"none"}">Generate Key</button>
-        <span class="msg" id="net-msg"></span>
-      </div>
-    </div>
+    ${networkMarkup(net)}
     <div id="agent-connect" class="card"></div>`
     + (vs.supported === false ? "" : `<div class="card"><h3>vLLM Backend (WSL2)</h3>
       <div class="kv"><span class="k">WSL2</span><span class="v ${vs.wsl.present?'ok':'bad'}">${vs.wsl.present?"installed":"NOT INSTALLED"}</span></div>
@@ -110,6 +509,7 @@ export async function loadSetup() {
       <div class="note">Downloads uv + a standalone Python and installs vLLM into ~/.llamaforge/vllm-venv. Several GB; watch the log.</div>`:""}
       <div class="log" id="vllm-setup-log" style="display:${(vs.setup_job&&vs.setup_job.running)?"":"none"}">${esc(vs.setup_log||"idle")}</div>
     </div>`));
+  wireNetwork(net);
   $$("[data-install]", v).forEach(b => b.onclick = async () => {
     b.disabled = true; b.textContent = "installing...";
     const r = await api("/api/setup/install", {tool: b.dataset.install});
@@ -133,31 +533,6 @@ export async function loadSetup() {
     await api("/api/config", {vram_bandwidths: ov});
     const m = $("#bw-msg"); m.className = "msg ok"; m.textContent = Object.keys(ov).length ? "saved" : "cleared (using defaults)";
   };
-  $("#net-lan").onchange = e => {
-    $("#net-keyrow").style.display = e.target.checked ? "" : "none";
-    $("#btn-net-genkey").style.display = e.target.checked ? "" : "none";
-  };
-  $("#btn-net-genkey").onclick = () => {
-    $("#net-apikey").value = [...crypto.getRandomValues(new Uint8Array(24))]
-      .map(b => b.toString(16).padStart(2,"0")).join("");
-  };
-  $("#btn-net-apply").onclick = async () => {
-    const msg = $("#net-msg"), lan = $("#net-lan").checked;
-    const host = lan ? "0.0.0.0" : "127.0.0.1";
-    const apiKey = $("#net-apikey").value.trim();
-    if (lan && $("#net-require-key").checked && !apiKey && !net.has_api_key) {
-      msg.className = "msg err";
-      msg.textContent = 'set or generate an API key first (or uncheck "require an API key")';
-      return;
-    }
-    msg.className = "msg work"; msg.textContent = "restarting router...";
-    const r = await api("/api/network", {host, api_key: lan?(apiKey||undefined):""});
-    if (r.ok) {
-      msg.className = "msg ok"; msg.textContent = "applied";
-      toast(lan?"LAN access enabled":"LAN access disabled", "ok");
-      setTimeout(loadSetup, 1500);
-    } else { msg.className = "msg err"; msg.textContent = r.error || "failed"; }
-  };
   const distroSel = $("#vllm-distro");
   if (distroSel) distroSel.onchange = () => api("/api/config", {wsl_distro: distroSel.value}).then(() => loadSetup());
   const instBtn = $("#btn-vllm-install");
@@ -172,58 +547,149 @@ export async function loadSetup() {
 }
 
 /* ---------- connect an agent ---------- */
-function agentModelOptions(sel) {
-  return models().map(m => `<option value="${esc(m.id)}"${m.id===sel?" selected":""}>${esc(m.id)}</option>`).join("");
+function agentModels() {
+  const active = cfgOf().active_engine || "llamacpp";
+  return models().filter(m =>
+    (m.backend === "llamacpp" || m.backend === "ikllama") &&
+    m.backend === active);
 }
+
+function agentModelOptions(selected = "") {
+  return agentModels().map(m =>
+    `<option value="${esc(m.id)}"${m.id === selected ? " selected" : ""}>${
+      esc(m.id)}</option>`).join("");
+}
+
+function clearAgentPreview(message = "Choose settings, then show the configuration.") {
+  const out = $("#ac-out");
+  if (out) setHTML(out, `<div class="note">${esc(message)}</div>`);
+}
+
+function agentRequest() {
+  const agent = $("#ac-agent").value;
+  const model = $("#ac-model").value;
+  const row = agentModels().find(m => m.id === model);
+  if (!row) return null;
+  return {
+    agent,
+    model,
+    backend: row.backend,
+    small: agent === "claude-code" ? $("#ac-small").value : "",
+    inject: agent !== "claude-code" && $("#ac-inject").checked,
+  };
+}
+
 function renderAgentConnect() {
-  const host = $("#agent-connect"); if (!host) return;
+  const host = $("#agent-connect");
+  if (!host) return;
   setHTML(host, `<h3>Connect an agent</h3>
-    <div class="note">Point a coding agent at your local models. Claude Code uses the
-      Anthropic-compatible endpoint; Codex and pi.dev use the OpenAI-compatible router.</div>
-    <div style="margin-top:8px">
-      <select id="ac-agent">
-        <option value="claude-code">Claude Code</option>
-        <option value="codex">Codex</option>
-        <option value="pi">pi.dev</option>
-      </select>
-      <select id="ac-model">${agentModelOptions()}</select>
-      <select id="ac-small" hidden>${agentModelOptions()}</select>
-      <button id="ac-apply" class="primary">Apply</button>
+    <div class="note">Generate or apply configuration only when requested.
+      Context injection uses this machine's loopback-only panel.</div>
+    <div class="agent-controls">
+      <label>Agent
+        <select id="ac-agent">
+          <option value="claude-code">Claude Code</option>
+          <option value="codex">Codex</option>
+          <option value="pi">pi.dev</option>
+        </select>
+      </label>
+      <label>Model <select id="ac-model">${agentModelOptions()}</select></label>
+      <label id="ac-small-wrap">Small model
+        <select id="ac-small">${agentModelOptions()}</select>
+      </label>
+      <label id="ac-inject-wrap" hidden>
+        <input id="ac-inject" type="checkbox">
+        Inject local context through the panel (this machine only)
+      </label>
+      <button id="ac-show" type="button">Show configuration</button>
+      <button id="ac-apply" type="button" class="primary">Apply</button>
     </div>
     <div id="ac-out" class="agent-out"></div>`);
-  const agentSel = $("#ac-agent"), smallSel = $("#ac-small");
-  const syncSmall = () => { smallSel.hidden = agentSel.value !== "claude-code"; };
-  syncSmall();
-  agentSel.onchange = () => { syncSmall(); loadAgentConfig(); };
-  $("#ac-model").onchange = loadAgentConfig;
-  smallSel.onchange = loadAgentConfig;
+
+  const sync = () => {
+    const claude = $("#ac-agent").value === "claude-code";
+    $("#ac-small-wrap").hidden = !claude;
+    $("#ac-inject-wrap").hidden = claude;
+    if (claude) $("#ac-inject").checked = false;
+    clearAgentPreview();
+  };
+  $("#ac-agent").onchange = sync;
+  $("#ac-model").onchange = () => clearAgentPreview();
+  $("#ac-small").onchange = () => clearAgentPreview();
+  $("#ac-inject").onchange = () => clearAgentPreview();
+  $("#ac-show").onclick = showAgentConfig;
   $("#ac-apply").onclick = applyAgentConfig;
-  loadAgentConfig();
+  sync();
 }
-async function loadAgentConfig() {
-  const agentSel = $("#ac-agent"), modelSel = $("#ac-model"), smallSel = $("#ac-small");
-  if (!agentSel || !modelSel || !smallSel || !modelSel.value) {
-    setHTML($("#ac-out"), `<div class="note">No models available yet &mdash; scan for models above first.</div>`);
+
+async function showAgentConfig() {
+  const body = agentRequest();
+  if (!body) {
+    clearAgentPreview("No llama-family model is available.");
+    $("#ac-model").focus();
     return;
   }
-  const agent = agentSel.value, model = modelSel.value;
-  const small = smallSel.hidden ? "" : smallSel.value;
-  let q = `/api/agent/config?agent=${encodeURIComponent(agent)}&model=${encodeURIComponent(model)}`;
-  if (small) q += `&small=${encodeURIComponent(small)}`;
-  const r = await api(q);
-  if (r.error) { setHTML($("#ac-out"), `<div class="note" style="color:var(--red)">${esc(r.error)}</div>`); return; }
-  const snip = (label, text) => `<div class="slabel">${esc(label)}</div><div class="snip"><button class="qbtn scopy" data-copytext="${esc(text)}">Copy</button>${esc(text)}</div>`;
-  setHTML($("#ac-out"),
-    `<div class="note">Target: <b>${esc(r.target_path)}</b> &middot; endpoint <b>${esc(r.endpoint)}</b><br>${esc(r.instructions)}</div>`
-    + snip(r.target_path, r.content));
+  const out = $("#ac-out");
+  const stillCurrent = () => {
+    if (!out.isConnected || out !== $("#ac-out")) return false;
+    const current = agentRequest();
+    return current !== null && JSON.stringify(current) === JSON.stringify(body);
+  };
+  setHTML(out,
+    `<div class="note" role="status">Generating configuration...</div>`);
+  let r;
+  try {
+    r = await api("/api/agent/config", body);
+  } catch (requestError) {
+    if (stillCurrent()) {
+      setHTML(out,
+        `<div class="note" role="alert">Agent configuration is unavailable.</div>`);
+    }
+    return;
+  }
+  if (!stillCurrent()) return;
+  if (r.error) {
+    setHTML(out,
+      `<div class="note" role="alert">${esc(r.error)}</div>`);
+    return;
+  }
+  const privateValues = [r.content];
+  setHTML(out,
+    `<div class="note">Target: <b>${esc(r.target_path)}</b> · endpoint
+      <b>${esc(r.endpoint)}</b><br>${esc(r.instructions)}</div>
+      <div class="slabel">${esc(r.target_path)}</div>
+      <div class="snip"><button type="button" class="qbtn scopy"
+        data-agent-copy-index="0" aria-label="Copy agent configuration">Copy</button>${
+        esc(r.content)}</div>`);
+  $$("[data-agent-copy-index]", out).forEach(button => {
+    const value = privateValues[Number(button.dataset.agentCopyIndex)];
+    button.removeAttribute("data-agent-copy-index");
+    button.onclick = () => navigator.clipboard.writeText(value).then(
+      () => toast("Copied to clipboard", "ok"));
+  });
 }
+
 async function applyAgentConfig() {
-  const agentSel = $("#ac-agent"), modelSel = $("#ac-model"), smallSel = $("#ac-small");
-  if (!modelSel || !modelSel.value) { toast("No model selected", "err"); return; }
-  const small = smallSel.hidden ? "" : smallSel.value;
-  const r = await api("/api/agent/apply", {agent: agentSel.value, model: modelSel.value, small});
-  if (r.error) { toast(r.error, "err"); return; }
-  toast(`${r.action}: ${r.path}${r.backup?` (backup: ${r.backup})`:""}`, "ok");
+  const body = agentRequest();
+  if (!body) {
+    clearAgentPreview("No llama-family model is available.");
+    $("#ac-model").focus();
+    return;
+  }
+  let r;
+  try {
+    r = await api("/api/agent/apply", body);
+  } catch (requestError) {
+    setHTML($("#ac-out"),
+      `<div class="note" role="alert">Agent configuration could not be applied.</div>`);
+    return;
+  }
+  if (r.error) {
+    setHTML($("#ac-out"),
+      `<div class="note" role="alert">${esc(r.error)}</div>`);
+    return;
+  }
+  clearAgentPreview(`${r.action}: ${r.path}${r.backup ? " (backup created)" : ""}`);
 }
 
 /* ---------- drive scanning ---------- */

--- a/web/js/stats-facts.js
+++ b/web/js/stats-facts.js
@@ -1,0 +1,183 @@
+// Human-scale comparisons for generated tokens. Every number is deliberately
+// approximate: token-to-word ratios vary by language/model, book counts vary by
+// edition, and route distances vary by road choice.
+const WORDS_PER_TOKEN = 0.75;
+const ORAL_WORDS_PER_MINUTE = 183;
+
+const BOOKS = [
+  ["harry-potter-1", "copy", "copies", "Harry Potter and the Philosopher's Stone", 76_944],
+  ["harry-potter-series", "complete", "complete", "Harry Potter series", 1_084_170],
+  ["lord-of-the-rings", "copy", "copies", "The Lord of the Rings", 481_103],
+  ["war-and-peace", "copy", "copies", "War and Peace", 561_304],
+  ["moby-dick", "copy", "copies", "Moby-Dick", 206_052],
+  ["pride-and-prejudice", "copy", "copies", "Pride and Prejudice", 121_934],
+  ["alice-in-wonderland", "copy", "copies", "Alice's Adventures in Wonderland", 27_170],
+  ["huckleberry-finn", "copy", "copies", "Adventures of Huckleberry Finn", 110_997],
+  ["jungle-book", "copy", "copies", "The Jungle Book", 51_090],
+  ["war-of-the-worlds", "copy", "copies", "The War of the Worlds", 60_556],
+  ["wizard-of-oz", "copy", "copies", "The Wonderful Wizard of Oz", 39_074],
+  ["hound-baskervilles", "copy", "copies", "The Hound of the Baskervilles", 59_132],
+  ["peter-pan", "copy", "copies", "Peter Pan", 47_097],
+  ["martin-eden", "copy", "copies", "Martin Eden", 139_281],
+  ["fahrenheit-451", "copy", "copies", "Fahrenheit 451", 46_118],
+  ["to-kill-a-mockingbird", "copy", "copies", "To Kill a Mockingbird", 100_388],
+  ["common-sense", "copy", "copies", "Common Sense", 25_033],
+  ["politics-english-language", "copy", "copies", "Politics and the English Language", 5_980],
+];
+
+const MOVIES = [
+  ["titanic", "Titanic", 195],
+  ["oppenheimer", "Oppenheimer", 180],
+  ["avengers-endgame", "Avengers: Endgame", 181],
+  ["godfather", "The Godfather", 175],
+  ["seven-samurai", "Seven Samurai", 207],
+  ["spirited-away", "Spirited Away", 125],
+  ["dark-knight", "The Dark Knight", 152],
+  ["matrix", "The Matrix", 136],
+  ["star-wars", "Star Wars", 121],
+  ["inception", "Inception", 148],
+  ["interstellar", "Interstellar", 169],
+  ["dune-part-two", "Dune: Part Two", 166],
+  ["shawshank", "The Shawshank Redemption", 142],
+  ["jurassic-park", "Jurassic Park", 127],
+  ["lotr-extended", "The Lord of the Rings extended trilogy", 683],
+];
+
+// Approximate road distances, rounded so the UI does not imply false precision.
+const ROUTES = [
+  ["munich-frankfurt", "Munich–Frankfurt", 400],
+  ["berlin-paris", "Berlin–Paris", 1_050],
+  ["london-edinburgh", "London–Edinburgh", 650],
+  ["new-york-washington", "New York–Washington, DC", 365],
+  ["los-angeles-san-francisco", "Los Angeles–San Francisco", 615],
+  ["boston-new-york", "Boston–New York", 350],
+  ["toronto-montreal", "Toronto–Montreal", 540],
+  ["sydney-melbourne", "Sydney–Melbourne", 880],
+  ["tokyo-osaka", "Tokyo–Osaka", 500],
+  ["delhi-agra", "Delhi–Agra", 230],
+  ["bengaluru-chennai", "Bengaluru–Chennai", 350],
+  ["rome-milan", "Rome–Milan", 575],
+  ["madrid-barcelona", "Madrid–Barcelona", 620],
+  ["lisbon-porto", "Lisbon–Porto", 315],
+  ["amsterdam-brussels", "Amsterdam–Brussels", 210],
+  ["copenhagen-stockholm", "Copenhagen–Stockholm", 655],
+  ["oslo-bergen", "Oslo–Bergen", 465],
+  ["cape-town-johannesburg", "Cape Town–Johannesburg", 1_400],
+  ["nairobi-mombasa", "Nairobi–Mombasa", 485],
+  ["buenos-aires-cordoba", "Buenos Aires–Córdoba", 700],
+  ["vienna-prague", "Vienna–Prague", 335],
+  ["zurich-geneva", "Zürich–Geneva", 280],
+  ["seattle-portland", "Seattle–Portland", 280],
+  ["dubai-abu-dhabi", "Dubai–Abu Dhabi", 140],
+  ["kuala-lumpur-singapore", "Kuala Lumpur–Singapore", 350],
+];
+
+const PACES = [
+  ["car", "trip", "trips", "by car", 100],
+  ["walk", "journey", "journeys", "at walking pace", 5],
+  ["cycle", "journey", "journeys", "at cycling pace", 20],
+  ["rail", "journey", "journeys", "at high-speed-rail pace", 250],
+];
+
+function rounded(value) {
+  const places = value < 10 ? 2 : value < 100 ? 1 : 1;
+  return Number(value.toFixed(places));
+}
+
+function shown(value) {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 10_000) return `${(value / 1_000).toFixed(1)}k`;
+  return String(value);
+}
+
+function comparison(id, value, singular, plural, assumption) {
+  const amount = rounded(value);
+  const unit = Math.abs(amount - 1) < 0.05 ? singular : plural;
+  return {id, amount, text: `${shown(amount)} ${unit}`, assumption};
+}
+
+export function buildTokenFacts(generatedTokens) {
+  const tokens = Math.max(0, Number(generatedTokens) || 0);
+  const words = tokens * WORDS_PER_TOKEN;
+  const spokenMinutes = words / ORAL_WORDS_PER_MINUTE;
+  const common = "English estimate: 0.75 words/token";
+  const facts = [];
+
+  for (const [id, singular, plural, title, wordCount] of BOOKS) {
+    const one = id === "harry-potter-series" ? `complete ${title}` : `${singular} of ${title}`;
+    const many = id === "harry-potter-series" ? `complete ${title}` : `${plural} of ${title}`;
+    facts.push(comparison(
+      `book:${id}`, words / wordCount, one, many,
+      `${common}; ${title}: approximately ${wordCount.toLocaleString()} words`,
+    ));
+  }
+  for (const [id, title, runtime] of MOVIES) {
+    facts.push(comparison(
+      `movie:${id}`, spokenMinutes / runtime, `back-to-back screening of ${title}`, `back-to-back screenings of ${title}`,
+      `${common}; read aloud at 183 words/minute; ${title}: approximately ${runtime} minutes`,
+    ));
+  }
+  for (const [routeId, route, distance] of ROUTES) {
+    for (const [paceId, singular, plural, suffix, speed] of PACES) {
+      const travelled = spokenMinutes / 60 * speed;
+      facts.push(comparison(
+        `route:${paceId}:${routeId}`, travelled / distance, `${route} ${singular} ${suffix}`, `${route} ${plural} ${suffix}`,
+        `${common}; read aloud at 183 words/minute; ${speed} km/h; ${route}: approximately ${distance.toLocaleString()} km`,
+      ));
+    }
+  }
+  return facts;
+}
+
+export function createFactRotator({random = Math.random, intervalMs = 15 * 60 * 1000} = {}) {
+  let selectedId = null;
+  let expiresAt = -Infinity;
+  return (generatedTokens, now = Date.now()) => {
+    if (!(Number(generatedTokens) > 0)) {
+      selectedId = null;
+      expiresAt = -Infinity;
+      return {id: "empty", amount: 0, text: "Generate some tokens to unlock a real-world comparison", assumption: "Uses generated output tokens only"};
+    }
+    const catalog = buildTokenFacts(generatedTokens);
+    const current = catalog.find(fact => fact.id === selectedId);
+    if (current && now < expiresAt) return current;
+
+    // A technically correct "0.00 books" is still a useless comparison. Until
+    // a named anchor reaches a readable tenth, show the underlying word scale.
+    const eligible = catalog.filter(fact => fact.amount >= 0.1);
+    if (!eligible.length) {
+      const amount = rounded(Number(generatedTokens) * WORDS_PER_TOKEN);
+      return {id: "words", amount, text: `${shown(amount)} English words`, assumption: "English estimate: 0.75 words/token"};
+    }
+    let next = Math.min(eligible.length - 1, Math.floor(Math.max(0, random()) * eligible.length));
+    if (eligible.length > 1 && eligible[next].id === selectedId) {
+      next = Math.min(eligible.length - 1, Math.floor(Math.max(0, random()) * eligible.length));
+      if (eligible[next].id === selectedId) {
+        next = (eligible.findIndex(fact => fact.id === selectedId) + 1) % eligible.length;
+      }
+    }
+    selectedId = eligible[next].id;
+    expiresAt = now + intervalMs;
+    return eligible[next];
+  };
+}
+
+export function normalizeVram(payload) {
+  if (!payload || !Array.isArray(payload.gpus)) return [];
+  return payload.gpus.flatMap((gpu, position) => {
+    const total = Number(gpu && gpu.total);
+    if (!Number.isFinite(total) || total <= 0) return [];
+    const rawUsed = Number(gpu.used);
+    const used = Number.isFinite(rawUsed) ? Math.min(total, Math.max(0, rawUsed)) : 0;
+    const numeric = key => Number.isFinite(Number(gpu[key])) ? Number(gpu[key]) : null;
+    return [{
+      index: gpu.index == null ? position : gpu.index,
+      name: gpu.name || `GPU ${position}`,
+      used,
+      total,
+      free: total - used,
+      util: numeric("util"),
+      temp: numeric("temp"),
+    }];
+  });
+}

--- a/web/js/stats.js
+++ b/web/js/stats.js
@@ -1,7 +1,10 @@
 // Stats tab: totals, live throughput, a daily activity chart, per-model usage.
-import { $, esc, setHTML, api, toast, fmtNum, fmtDur, fmtAgo } from "./core.js";
+import { $, esc, setHTML, api, toast, fmtNum, fmtDur, fmtAgo, meter } from "./core.js";
+import { createFactRotator, normalizeVram } from "./stats-facts.js";
 
-let statsSort = "tokens", statsRange = 14;
+let statsSort = "tokens", statsRange = 14, statsRequest = 0;
+let gpuRequest = null, lastGpuPayload, hasGpuPayload = false;
+const tokenFact = createFactRotator();
 const SORT_COLS = {tokens:"Total", prompt:"Prompt", generated:"Gen",
                    avg_tps:"Tok/s", runs:"Runs", loaded_secs:"Loaded"};
 
@@ -32,11 +35,48 @@ function statCard(label, val) {
   return `<div class="gpu"><div class="stats" style="margin:0"><span>${esc(label)}</span></div><div style="font-family:var(--disp);font-weight:600;color:var(--ink-strong);font-size:22px;margin-top:6px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${esc(val)}</div></div>`;
 }
 
+export function renderStatsVram(payload) {
+  const gpus = normalizeVram(payload);
+  if (!gpus.length) return `<div class="stats-vram-empty">VRAM TELEMETRY UNAVAILABLE</div>`;
+  return gpus.map(gpu => { const usedGb = (gpu.used/1024).toFixed(1), totalGb = (gpu.total/1024).toFixed(1);
+    return `<div class="stats-vram-card">
+    <div class="stats-vram-head"><span>${esc(gpu.name)}</span><span>GPU ${esc(gpu.index)}</span></div>
+    <div class="meter" role="progressbar" aria-label="${esc(gpu.name)} VRAM used" aria-valuemin="0" aria-valuenow="${esc(gpu.used)}" aria-valuemax="${esc(gpu.total)}" aria-valuetext="${esc(usedGb)} of ${esc(totalGb)} GB used">${meter(gpu.used, gpu.total)}</div>
+    <div class="stats"><span><b>${esc(usedGb)}</b>/${esc(totalGb)} GB</span><span>FREE <b>${esc((gpu.free/1024).toFixed(1))}</b> GB</span></div>
+  </div>`; }).join("");
+}
+
+export function renderTokenScale(generated, fact, open = false) {
+  const total = `${fmtNum(generated)} GENERATED`;
+  const accessible = `${total} is approximately ${fact.text}. ${fact.assumption}`;
+  return `<div class="token-scale">
+    <span class="token-scale-label">TOKEN SCALE //</span>
+    <span class="token-scale-total">${esc(total)}</span>
+    <span class="token-scale-mark" aria-hidden="true">≈</span>
+    <span class="token-scale-fact">${esc(fact.text)}</span>
+    <details class="token-scale-details"${open ? " open" : ""}>
+      <summary aria-label="${esc(accessible)}">EST.</summary>
+      <div class="token-scale-note"><b>${esc(total)} ≈ ${esc(fact.text)}</b><span>${esc(fact.assumption)}</span></div>
+    </details>
+  </div>`;
+}
+
+function refreshStatsVram() {
+  if (gpuRequest) return;
+  gpuRequest = api("/api/gpus").catch(() => null).then(payload => {
+    lastGpuPayload = payload;
+    hasGpuPayload = true;
+    setHTML($("#stats-vram"), renderStatsVram(payload));
+  }).finally(() => { gpuRequest = null; });
+}
+
 export async function loadStats(silent) {
+  const request = ++statsRequest;
   const v = $("#view-stats");
   if (!silent) setHTML(v, `<div class="skel">LOADING STATS...</div>`);
-  let s;
-  try { s = await api("/api/stats"); } catch (e) { s = null; }
+  refreshStatsVram();
+  const s = await api("/api/stats").catch(() => null);
+  if (request !== statsRequest) return;
   // fetch() doesn't reject on HTTP errors, so a 404/500 arrives as a parsed
   // error body, not an exception - guard on shape, not just the catch.
   if (!s || s.error || !Array.isArray(s.per_model)) {
@@ -47,7 +87,13 @@ export async function loadStats(silent) {
   const rows = [...s.per_model].sort((a,b) => (b[statsSort]||0) - (a[statsSort]||0));
   const daily = s.daily.slice(-statsRange);
   const maxDaily = Math.max(1, ...daily.map(d => d.prompt + d.generated));
+  const fact = tokenFact(t.generated);
+  const oldSummary = $(".token-scale-details summary", v);
+  const restoreDetailsFocus = !!oldSummary && document.activeElement === oldSummary;
+  const detailsOpen = !!$(".token-scale-details", v)?.open;
   setHTML(v, `
+    ${renderTokenScale(t.generated, fact, detailsOpen)}
+    <div class="stats-vram" id="stats-vram" aria-label="GPU VRAM usage">${hasGpuPayload ? renderStatsVram(lastGpuPayload) : `<div class="stats-vram-empty">VRAM TELEMETRY LOADING...</div>`}</div>
     <div class="gpus" style="grid-template-columns:repeat(auto-fit,minmax(150px,1fr))">
       ${statCard("Tokens processed", fmtNum(t.tokens))}
       ${statCard("Generated", fmtNum(t.generated))}
@@ -97,4 +143,5 @@ export async function loadStats(silent) {
         </div></div>`).join("")}</div>`
       :`<div class="note">No models have logged usage yet.</div>`}
     </div>`);
+  if (restoreDetailsFocus) $(".token-scale-details summary", v)?.focus({preventScroll: true});
 }

--- a/web/js/ui.js
+++ b/web/js/ui.js
@@ -111,9 +111,12 @@ export function initDrawer() {
 
 /* ---------- tabs ---------- */
 const tabHandlers = {};
+const tabHiddenHandlers = {};
 /** Register the loader for a tab. main.js wires every view through this, which
  *  is what keeps ui.js free of imports from the views themselves. */
 export function onTabShown(name, fn) { tabHandlers[name] = fn; }
+/** Register cleanup that must run synchronously before a view is hidden. */
+export function onTabHidden(name, fn) { tabHiddenHandlers[name] = fn; }
 
 export function switchTab(name) {
   const t = $(`.tab[data-tab="${name}"]`);
@@ -126,6 +129,12 @@ export function updatePageTitle() {
 }
 export function initTabs() {
   $$(".tab").forEach(t => t.onclick = () => {
+    const previous = $(".tab.active");
+    const previousName = previous ? previous.dataset.tab : "";
+    if (previousName && previousName !== t.dataset.tab) {
+      const hide = tabHiddenHandlers[previousName];
+      if (hide) hide();
+    }
     $$(".tab").forEach(x => x.classList.remove("active"));
     t.classList.add("active");
     $$(".view").forEach(v => v.classList.remove("active"));


### PR DESCRIPTION
## Summary

- harden dashboard request framing and add a fail-closed router network policy
- add explicit, redacted client and agent configuration flows with bounded credential lifetimes
- preflight Windows and POSIX launchers before exposing the router
- add named token-scale comparisons and compact VRAM telemetry to Stats
- document the security model, configuration, API, setup, and new Stats behavior

## Testing

- 530 Python unit tests passed with 3 expected platform-specific skips
- 11 Node frontend behavior tests passed
- all frontend JavaScript syntax checks passed
- real Chrome security and accessibility fixture passed
- final whole-branch review reported no actionable findings