### PR TITLE
fix: authenticate internal router requests

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -195,10 +195,15 @@ def _wiki_export(body):
 
 # ---------- router proxy ----------
 def router(path, method="GET", body=None, timeout=30):
-    url = router_base() + path
+    c = cfg()
+    url = f"http://127.0.0.1:{c['router_port']}" + path
     data = json.dumps(body).encode() if body is not None else None
+    headers = {"Content-Type": "application/json"}
+    key = c.get("router_api_key", "")
+    if key:
+        headers["Authorization"] = "Bearer " + key
     req = urllib.request.Request(url, data=data, method=method,
-                                 headers={"Content-Type": "application/json"})
+                                 headers=headers)
     try:
         with urllib.request.urlopen(req, timeout=timeout) as r:
             return r.status, json.loads(r.read().decode() or "{}")
@@ -416,8 +421,12 @@ def _autotune_refine(body):
         payload = {"model": mid, "prompt": prompt, "n_predict": 200, "stream": True}
         url = router_base() + "/completion"
         data = json.dumps(payload).encode()
+        headers = {"Content-Type": "application/json"}
+        key = cfg().get("router_api_key", "")
+        if key:
+            headers["Authorization"] = "Bearer " + key
         req = urllib.request.Request(url, data=data, method="POST",
-                                     headers={"Content-Type": "application/json"})
+                                     headers=headers)
         tokens = 0
         first_tok = None
         last_tok = None

--- a/backend/stats.py
+++ b/backend/stats.py
@@ -105,7 +105,14 @@ class StatsTracker:
         return f"http://127.0.0.1:{config.load()['router_port']}"
 
     def _get(self, path, timeout=4):
-        with urllib.request.urlopen(self._base() + path, timeout=timeout) as r:
+        c = config.load()
+        headers = {}
+        key = c.get("router_api_key", "")
+        if key:
+            headers["Authorization"] = "Bearer " + key
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{c['router_port']}" + path, headers=headers)
+        with urllib.request.urlopen(req, timeout=timeout) as r:
             return r.read().decode(errors="replace")
 
     def _router_state(self):

--- a/tests/test_routes_api.py
+++ b/tests/test_routes_api.py
@@ -4,11 +4,41 @@ Each handler is now a plain function of Req -> (status, payload), so these run
 with no socket and no live router.
 """
 import conftest_paths  # noqa: F401
-import os, tempfile, unittest
+import json, os, tempfile, unittest
 from unittest import mock
 
 import config, routes
 from routes import Req, ApiError
+
+
+class RouterAuthenticationTest(unittest.TestCase):
+    def test_internal_router_requests_include_configured_bearer_key(self):
+        seen = {}
+
+        class Response:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+            def read(self):
+                return json.dumps({"data": []}).encode()
+
+        def open_request(request, timeout=30):
+            seen["authorization"] = request.get_header("Authorization")
+            return Response()
+
+        with mock.patch.object(routes, "cfg", return_value={
+                "router_port": 8080, "router_api_key": "secret-key"}), \
+             mock.patch.object(routes.urllib.request, "urlopen",
+                               side_effect=open_request):
+            status, _ = routes.router("/models")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(seen["authorization"], "Bearer secret-key")
 
 
 class ConfigAllowlistTest(unittest.TestCase):

--- a/tests/test_stats_router.py
+++ b/tests/test_stats_router.py
@@ -1,6 +1,7 @@
 import conftest_paths  # noqa: F401
 import json, os, tempfile, unittest, urllib.error
 import stats
+from unittest import mock
 
 
 class RouterCase(unittest.TestCase):
@@ -38,6 +39,32 @@ class RouterCase(unittest.TestCase):
 
 
 class TestRouterMetricsScrape(RouterCase):
+    def test_router_scrapes_include_configured_bearer_key(self):
+        seen = {}
+
+        class Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+            def read(self):
+                return b'{"data": []}'
+
+        def open_request(request, timeout=4):
+            seen["authorization"] = (request.get_header("Authorization")
+                                      if hasattr(request, "get_header") else None)
+            return Response()
+
+        with mock.patch.object(stats.config, "load", return_value={
+                "router_port": 8080, "router_api_key": "secret-key"}), \
+             mock.patch.object(stats.urllib.request, "urlopen",
+                               side_effect=open_request):
+            self.tr._get("/models")
+
+        self.assertEqual(seen["authorization"], "Bearer secret-key")
+
     def test_router_up_and_tokens_attributed(self):
         self._wire(prompt=10, gen=20)
         self.tr.poll_once()                       # baseline


### PR DESCRIPTION
Fixes the API-key regression that made model loading return unauthorized and caused Models and Stats to report the router or loaded model incorrectly. Internal router proxy, stats polling, and autotune completion requests now send the configured Bearer credential without exposing it. Regression coverage was added for the shared router and stats paths. Verification: 562 tests passed, 3 skipped.